### PR TITLE
Add Persian (Farsi) Translation for SAS Planet

### DIFF
--- a/fa.po
+++ b/fa.po
@@ -1,0 +1,3385 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: SAS Planet\n"
+"POT-Creation-Date: 2018-10-21 22:00\n"
+"PO-Revision-Date: 2024-12-10 00:23+0330\n"
+"Last-Translator: Yago <dmurias@hotmail.com>\n"
+"Language-Team: Barzin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2\n"
+"Language: fa\n"
+"Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+msgid " RosCosmos "
+msgstr "RosCosmos"
+
+msgid " Storage "
+msgstr "ذخیره سازی"
+
+msgid " To "
+msgstr "به"
+
+msgid "%0:s (MultiPath %d)"
+msgstr "%0:s (چند مسیر %d)"
+
+msgid "%0:s (MultiPlacemark %d)"
+msgstr "%0:s (چند مکان %d)"
+
+msgid "%0:s (MultiPolygon %d)"
+msgstr "%0:s (چند ضلعی %d)"
+
+msgid "%0:s (Path)"
+msgstr "%0:s (مسیر)"
+
+msgid "%0:s (Placemark)"
+msgstr "%0:s (نشان مکان)"
+
+msgid "%0:s (Polygon)"
+msgstr "%0:s (چند ضلعی)"
+
+msgid "%0:s Downloading"
+msgstr "%0:s در حال دانلود"
+
+msgid "%s %.2f of %.2f MB (%.2f%s)"
+msgstr "%s %.2f از %.2f مگابایت (%.2f%s)"
+
+msgid "&Coordinates"
+msgstr "&مختصات"
+
+msgid "&Copy to Clipboard"
+msgstr "&در کلیپ بورد کپی کنید"
+
+msgid "&Help"
+msgstr "&راهنما"
+
+msgid "&Maps"
+msgstr "&نقشه ها"
+
+msgid "&Operations"
+msgstr "&عملیات"
+
+msgid "&Source"
+msgstr "&منبع"
+
+msgid "&View"
+msgstr "&مشاهده"
+
+msgid "&hl=en"
+msgstr "&hl=en"
+
+msgid "(%s not found!)"
+msgstr "(%s پیدا نشد!)"
+
+msgid "(zoom %)"
+msgstr "(زوم %)"
+
+msgid "* - Limited by max concurrent http(s) requests for current map: %d"
+msgstr "* - محدود به حداکثر درخواست همزمان http(ها) برای نقشه فعلی: %d"
+
+msgid "-- deg. (-12.1233°)"
+msgstr "-- درجه (-12.1233°)"
+
+msgid "-- deg.min. (-12°23.454)"
+msgstr "-- درجه. دقیقه (-12°23.454)"
+
+msgid "-- deg.min.sec. (-12°23\"43.35')"
+msgstr "-- deg.min.sec. (-12°23\"43.35')"
+
+msgid "/pixel"
+msgstr "/ پیکسل"
+
+msgid "0..9 max"
+msgstr "حداکثر 0..9"
+
+msgid "1.2km"
+msgstr "1.2 کیلومتر"
+
+msgid "100..1 max"
+msgstr "حداکثر 100..1"
+
+msgid "12 km 423 m"
+msgstr "12 کیلومتر 423 متر"
+
+msgid "120km"
+msgstr "120 کیلومتر"
+
+msgid "120m"
+msgstr "120 متر"
+
+msgid "128x128 pix"
+msgstr "128x128 پیکسل"
+
+msgid "12km"
+msgstr "12 کیلومتر"
+
+msgid "12m"
+msgstr "12 متر"
+
+msgid "1:1 000 000 (10 km)"
+msgstr "1:1 000 000 (10 کیلومتر)"
+
+msgid "1:10 000 (100 m)"
+msgstr "1:10 000 (100 متر)"
+
+msgid "1:100 000 (1 km)"
+msgstr "1:100 000 (1 کیلومتر)"
+
+msgid "1:2 500 (25 m)"
+msgstr "1:2 500 (25 متر)"
+
+msgid "1:200 000 (2 km)"
+msgstr "1:200 000 (2 کیلومتر)"
+
+msgid "1:25 000 (250 m)"
+msgstr "1:25 000 (250 متر)"
+
+msgid "1:5 000 (50 m)"
+msgstr "1:5 000 (50 متر)"
+
+msgid "1:50 000 (500 m)"
+msgstr "1:50 000 (500 متر)"
+
+msgid "1:500 000 (5 km)"
+msgstr "1:500 000 (5 کیلومتر)"
+
+msgid "2,07 km2"
+msgstr "2,07 کیلومتر مربع"
+
+msgid "200km"
+msgstr "200 کیلومتر"
+
+msgid "200m"
+msgstr "200 متر"
+
+msgid "206,63 ha"
+msgstr "206,63 هکتار"
+
+msgid "2066339 m2"
+msgstr "2066339 متر مربع"
+
+msgid "20km"
+msgstr "20 کیلومتر"
+
+msgid "20m"
+msgstr "20 متر"
+
+msgid "23.4 km"
+msgstr "23.4 کیلومتر"
+
+msgid "256x256 pix"
+msgstr "256x256 پیکسل"
+
+msgid "2km"
+msgstr "2 کیلومتر"
+
+msgid "300km"
+msgstr "300 کیلومتر"
+
+msgid "300m"
+msgstr "300 متر"
+
+msgid "30km"
+msgstr "30 کیلومتر"
+
+msgid "30m"
+msgstr "30 متر"
+
+msgid "3km"
+msgstr "3 کیلومتر"
+
+msgid "500km"
+msgstr "500 کیلومتر"
+
+msgid "500m"
+msgstr "500 متر"
+
+msgid "50km"
+msgstr "50 کیلومتر"
+
+msgid "50m"
+msgstr "50 متر"
+
+msgid "5km"
+msgstr "5 کیلومتر"
+
+msgid "5m"
+msgstr "5 متر"
+
+msgid "800km"
+msgstr "800 کیلومتر"
+
+msgid "800m"
+msgstr "800 متر"
+
+msgid "80km"
+msgstr "80 کیلومتر"
+
+msgid "80m"
+msgstr "80 متر"
+
+msgid "8km"
+msgstr "8 کیلومتر"
+
+msgid "8m"
+msgstr "8 متر"
+
+msgid "AUX for LizardTech GeoExpress Server"
+msgstr "AUX برای سرور LizardTech GeoExpress"
+
+msgid "Abort"
+msgstr "سقط"
+
+msgid "About"
+msgstr "درباره"
+
+msgid "Active"
+msgstr "فعال"
+
+msgid "Active Layers (%d)"
+msgstr "لایه‌های فعال (%d)"
+
+msgid "Active Maps (%d)"
+msgstr "نقشه‌های فعال (%d)"
+
+msgid "Active Maps + Layers (%d)"
+msgstr "نقشه‌های فعال + لایه‌ها (%d)"
+
+msgid "Add"
+msgstr "اضافه کنید"
+
+msgid "Add Category"
+msgstr "اضافه کردن دسته"
+
+msgid "Add Marks Database"
+msgstr "افزودن پایگاه داده علائم"
+
+msgid "Add New Category"
+msgstr "اضافه کردن دسته جدید"
+
+msgid "Add New Path"
+msgstr "اضافه کردن مسیر جدید"
+
+msgid "Add New Placemark"
+msgstr "علامت مکان جدید اضافه کنید"
+
+msgid "Add New Polygon"
+msgstr "افزودن چند ضلعی جدید"
+
+msgid "Add Path"
+msgstr "اضافه کردن مسیر"
+
+msgid "Add Placemark"
+msgstr "علامت مکان را اضافه کنید"
+
+msgid "Add Polygon"
+msgstr "اضافه کردن چند ضلعی"
+
+msgid "Add SubCategory"
+msgstr "اضافه کردن زیر مجموعه"
+
+msgid "Add Track to Database"
+msgstr "اضافه کردن آهنگ به پایگاه داده"
+
+msgid "Add a database"
+msgstr "یک پایگاه داده اضافه کنید"
+
+msgid "Add menu separator line after this map"
+msgstr "بعد از این نقشه خط جداکننده منو اضافه کنید"
+
+msgid "Add new path"
+msgstr "اضافه کردن مسیر جدید"
+
+msgid "Add new placemark"
+msgstr "مکان نشان جدید اضافه کنید"
+
+msgid "Add polygon"
+msgstr "افزودن چند ضلعی"
+
+msgid "Add tiles to database"
+msgstr "کاشی ها را به پایگاه داده اضافه کنید"
+
+msgid "Add to Favorites"
+msgstr "به موارد دلخواه اضافه کنید"
+
+msgid "Add to Merge Polygons"
+msgstr "اضافه کردن به Merge Polygons"
+
+msgid "Add to Merge Polygons (Ctrl+MLeft)"
+msgstr "افزودن به چند ضلعی ادغام (Ctrl+MLeft)"
+
+msgid "Add visible Cached Tiles Map"
+msgstr "نقشه کاشی های ذخیره شده قابل مشاهده را اضافه کنید"
+
+msgid "Add visible Grids"
+msgstr "شبکه های قابل مشاهده را اضافه کنید"
+
+msgid "Add visible Layers"
+msgstr "افزودن لایه های قابل مشاهده"
+
+msgid "Add visible Placemarks"
+msgstr "علامت‌های مکان قابل مشاهده را اضافه کنید"
+
+msgid "Add visible placemarks"
+msgstr "مکان‌های قابل مشاهده را اضافه کنید"
+
+msgid "Additional"
+msgstr "اضافی"
+
+msgid "Additional Operations"
+msgstr "عملیات اضافی"
+
+msgid "All"
+msgstr "همه"
+
+msgid "All (%d)"
+msgstr "همه (%d)"
+
+msgid "All Images"
+msgstr "همه تصاویر"
+
+msgid "All Services"
+msgstr "همه خدمات"
+
+msgid "All Visible"
+msgstr "همه قابل مشاهده است"
+
+msgid "All by default"
+msgstr "همه به صورت پیش فرض"
+
+msgid "All compatible formats"
+msgstr "همه فرمت های سازگار"
+
+msgid "Altitude"
+msgstr "ارتفاع"
+
+msgid "Any Available Source"
+msgstr "هر منبع موجود"
+
+msgid "Apply"
+msgstr "درخواست کنید"
+
+msgid "Approx. to download:"
+msgstr "تقریبا برای دانلود:"
+
+msgid "Are you sure you want to delete %0:d placemarks?"
+msgstr "آیا مطمئنید که می‌خواهید %0:d مکان‌مارک‌ها را حذف کنید؟"
+
+msgid "Are you sure you want to delete Marks in selected region?"
+msgstr "آیا مطمئن هستید که می‌خواهید علامت‌ها را در منطقه انتخابی حذف کنید؟"
+
+msgid "Are you sure you want to delete category with name \"%0:s\"?"
+msgstr "آیا مطمئن هستید که می خواهید دسته بندی با نام \"%0:s\" را حذف کنید؟"
+
+msgid "Are you sure you want to delete current GPS track?"
+msgstr "آیا مطمئن هستید که می خواهید مسیر GPS فعلی را حذف کنید؟"
+
+msgid "Are you sure you want to delete database \"%s\"?"
+msgstr "آیا مطمئن هستید که می خواهید پایگاه داده \"%s\" را حذف کنید؟"
+
+msgid "Are you sure you want to delete path with name \"%0:s\"?"
+msgstr "آیا مطمئن هستید که می خواهید مسیر با نام \"%0:s\" را حذف کنید؟"
+
+msgid ""
+"Are you sure you want to delete placemark of unknown type with name "
+"\"%0:s\"?"
+msgstr ""
+"آیا مطمئن هستید که می‌خواهید نشان مکان از نوع ناشناخته با نام \"%0:s\" را "
+"حذف کنید؟"
+
+msgid "Are you sure you want to delete point with name \"%0:s\"?"
+msgstr "آیا مطمئن هستید که می خواهید نقطه ای با نام \"%0:s\" را حذف کنید؟"
+
+msgid "Are you sure you want to delete polygon with name \"%0:s\"?"
+msgstr "آیا مطمئن هستید که می خواهید چند ضلعی با نام \"%0:s\" را حذف کنید؟"
+
+msgid "Are you sure you want to delete tile with name \"%0:s\"?"
+msgstr "آیا مطمئن هستید که می خواهید کاشی با نام \"%0:s\" را حذف کنید؟"
+
+msgid "Are you sure you want to delete tiles in selected region?"
+msgstr "آیا مطمئن هستید که می خواهید کاشی ها را در منطقه انتخاب شده حذف کنید؟"
+
+msgid "Are you sure you want to reset sensor?"
+msgstr "آیا مطمئن هستید که می خواهید سنسور را بازنشانی کنید؟"
+
+msgid "Area"
+msgstr "منطقه"
+
+msgid "Area representation"
+msgstr "نمایندگی منطقه"
+
+msgid "Area: %s"
+msgstr "منطقه: %s"
+
+msgid "Arrow color:"
+msgstr "رنگ پیکان:"
+
+msgid ""
+"At least one calibration type doesn't support file name with characters not "
+"from current locale!"
+msgstr ""
+"حداقل یک نوع کالیبراسیون از نام فایل با نویسه‌هایی که از محلی فعلی نیستند "
+"پشتیبانی نمی‌کند!"
+
+msgid "At least one calibration type supports file name with ASCII characters only!"
+msgstr ""
+"حداقل یک نوع کالیبراسیون از نام فایل فقط با کاراکترهای ASCII پشتیبانی می "
+"کند!"
+
+msgid "Attention!"
+msgstr "توجه!"
+
+msgid "Attribution:"
+msgstr "انتساب:"
+
+msgid "Auto"
+msgstr "خودکار"
+
+msgid "Auto show/hide sensors toolbar"
+msgstr "نوار ابزار سنسورها نمایش/پنهان کردن خودکار"
+
+msgid "Autodetect"
+msgstr "شناسایی خودکار"
+
+msgid "Autodetect COM port"
+msgstr "تشخیص خودکار پورت COM"
+
+msgid "Autodetect COM port on connect"
+msgstr "شناسایی خودکار پورت COM در اتصال"
+
+msgid "Autodetect on connect"
+msgstr "شناسایی خودکار در اتصال"
+
+msgid "Autosave track to:"
+msgstr "ذخیره خودکار آهنگ در:"
+
+msgid "Available version:"
+msgstr "نسخه موجود:"
+
+msgid "Average speed"
+msgstr "سرعت متوسط"
+
+msgid "Average speed, km/h:"
+msgstr "میانگین سرعت، کیلومتر در ساعت:"
+
+msgid "Azimuth"
+msgstr "آزیموت"
+
+msgid "Azimuth Circle"
+msgstr "دایره آزیموت"
+
+msgid "BMP: Fill line failure!"
+msgstr "BMP: خرابی خط پر کردن!"
+
+msgid "BMP: Line write failure!"
+msgstr "BMP: خط نوشتن ناموفق!"
+
+msgid "Background color"
+msgstr "رنگ پس زمینه"
+
+msgid "Background color:"
+msgstr "رنگ پس زمینه:"
+
+msgid "Base Cache path"
+msgstr "مسیر Cache پایه"
+
+msgid "Base part of request URL:"
+msgstr "بخش اصلی URL درخواست:"
+
+msgid "Battery"
+msgstr "باتری"
+
+msgid "Battery:"
+msgstr "باتری:"
+
+msgid "BerkeleyDB (Versioned)"
+msgstr "BerkeleyDB (نسخه شده)"
+
+msgid "BerkeleyDB (Versioned) cache folder:"
+msgstr "پوشه کش BerkeleyDB (Versioned):"
+
+msgid "BerkeleyDB cache folder:"
+msgstr "پوشه کش BerkeleyDB:"
+
+msgid "Bits per second"
+msgstr "بیت در ثانیه"
+
+msgid "Border color"
+msgstr "رنگ حاشیه"
+
+msgid "Build date:"
+msgstr "تاریخ ساخت:"
+
+msgid "Build info:"
+msgstr "اطلاعات ساخت:"
+
+msgid "By Bicycle (Fastest)"
+msgstr "با دوچرخه (سریعترین)"
+
+msgid "By Bicycle (Shortest)"
+msgstr "با دوچرخه (کوتاه ترین)"
+
+msgid "By Car (Fastest)"
+msgstr "با ماشین (سریعترین)"
+
+msgid "By Car (Shortest)"
+msgstr "با ماشین (کوتاه ترین)"
+
+msgid "By Coordinates"
+msgstr "توسط مختصات"
+
+msgid "By default"
+msgstr "به طور پیش فرض"
+
+msgid "COM"
+msgstr "COM"
+
+msgid "Cache"
+msgstr "حافظه پنهان"
+
+msgid "Cache Folder"
+msgstr "پوشه کش"
+
+msgid "Cache Manager"
+msgstr "مدیر کش"
+
+msgid "Cache Size, Mb:"
+msgstr "اندازه کش، مگابایت:"
+
+msgid "Cache and Other"
+msgstr "کش و سایر موارد"
+
+msgid "Cache conversion is finished!"
+msgstr "تبدیل کش به پایان رسید!"
+
+msgid ""
+"Cache converter aborted with error: Content-Type mismatch!\n"
+"Source: %s\n"
+"Destination: %s"
+msgstr ""
+"مبدل حافظه پنهان با خطا لغو شد: عدم تطابق نوع محتوا!\n"
+"منبع: %s\n"
+"مقصد: %s"
+
+msgid "Cache folder"
+msgstr "پوشه کش"
+
+msgid "Cache is Read-Only"
+msgstr "کش فقط خواندنی است"
+
+msgid "Cache type"
+msgstr "نوع کش"
+
+msgid "Cached Tiles Map"
+msgstr "نقشه کاشی های ذخیره شده"
+
+msgid "Cached tiles map"
+msgstr "نقشه کاشی های ذخیره شده"
+
+msgid "Cached tiles map:"
+msgstr "نقشه کاشی های ذخیره شده:"
+
+msgid "Calibration by World file and files with projection description"
+msgstr "کالیبراسیون توسط فایل World و فایل ها با توضیحات طرح ریزی"
+
+msgid "Calibration for Google Earth programm (*.kml)"
+msgstr "کالیبراسیون برای برنامه Google Earth (*.kml)"
+
+msgid "Calibration for MapInfo programm (*.tab)"
+msgstr "کالیبراسیون برای برنامه MapInfo (*.tab)"
+
+msgid "Calibration for OziExplorer programm (*.map)"
+msgstr "کالیبراسیون برای برنامه OziExplorer (*.map)"
+
+msgid "Calibration for Radio Mobile programm (*.dat)"
+msgstr "کالیبراسیون برای برنامه رادیویی موبایل (*.dat)"
+
+msgid "Can't acquire db: %s"
+msgstr "نمی توان db را بدست آورد: %s"
+
+msgid "Can't bound the Map - GUID not found!"
+msgstr "نمی توان نقشه را محدود کرد - GUID یافت نشد!"
+
+msgid "Can't initialize in-memory tile storage. Check your config!"
+msgstr "ذخیره سازی کاشی در حافظه راه اندازی نمی شود. تنظیمات خود را بررسی کنید!"
+
+msgid "Can't load bitmap from source type"
+msgstr "بیت مپ از نوع منبع بارگیری نمی شود"
+
+msgid "Can't open file: %s"
+msgstr "فایل باز نمی شود: %s"
+
+msgid "Can't release an object that is not in the pool!"
+msgstr "نمی توان جسمی را که در استخر نیست رها کرد!"
+
+msgid "Can't save bitmap to target type"
+msgstr "نمی توان بیت مپ را در نوع هدف ذخیره کرد"
+
+msgid "Can't use old pool record!"
+msgstr "نمی توان از رکورد قدیمی استخر استفاده کرد!"
+
+msgid "Cancel"
+msgstr "لغو کنید"
+
+msgid "Cannot connect to external tile storage"
+msgstr "نمی توان به حافظه خارجی کاشی متصل شد"
+
+msgid "Cannot parse tile to get its version"
+msgstr "نمی توان کاشی را برای دریافت نسخه آن تجزیه کرد"
+
+msgid "Caption parameters"
+msgstr "پارامترهای عنوان"
+
+msgid "Cascade"
+msgstr "آبشار"
+
+msgid "Category:"
+msgstr "دسته بندی:"
+
+msgid "Category: %s"
+msgstr "دسته: %s"
+
+msgid "Center With &Zoom"
+msgstr "مرکز با &بزرگنمایی"
+
+msgid "Centered GPS Position"
+msgstr "موقعیت GPS در مرکز"
+
+msgid "Charging"
+msgstr "شارژ کردن"
+
+msgid "Check for updates..."
+msgstr "بررسی به روز رسانی..."
+
+msgid "Close"
+msgstr "بستن"
+
+msgid "Close this window once finished"
+msgstr "پس از اتمام این پنجره را ببندید"
+
+msgid "Color"
+msgstr "رنگ"
+
+msgid "Color only"
+msgstr "فقط رنگ"
+
+msgid "Color:"
+msgstr "رنگ:"
+
+msgid "Comment"
+msgstr "نظر دهید"
+
+msgid "Community  (http://www.sasgis.org/forum)"
+msgstr "انجمن (http://www.sasgis.org/forum)"
+
+msgid ""
+"Compilation error in script \n"
+"%0:s"
+msgstr ""
+"خطای کامپایل در اسکریپت \n"
+"%0:s"
+
+msgid "Compiler:"
+msgstr "کامپایلر:"
+
+msgid "Compressing to TAR"
+msgstr "فشرده سازی به TAR"
+
+msgid "Compressing to ZIP"
+msgstr "فشرده سازی به ZIP"
+
+msgid "Compression (for PNG):"
+msgstr "فشرده سازی (برای PNG):"
+
+msgid "Compression:"
+msgstr "فشرده سازی:"
+
+msgid "Connect to GPS Receiver"
+msgstr "اتصال به گیرنده GPS"
+
+msgid "Connect to GPS receiver"
+msgstr "اتصال به گیرنده GPS"
+
+msgid "Connect to server error. Error code %d"
+msgstr "خطای اتصال به سرور کد خطا %d"
+
+msgid "Connection settings"
+msgstr "تنظیمات اتصال"
+
+msgid "Connection string"
+msgstr "رشته اتصال"
+
+msgid "Connection to external tile storage is dead and cannot be reestablished"
+msgstr ""
+"اتصال به فضای ذخیره‌سازی کاشی خارجی قطع شده است و نمی‌توان آن را دوباره "
+"برقرار کرد"
+
+msgid "Contrast"
+msgstr "کنتراست"
+
+msgid "Control"
+msgstr "کنترل کنید"
+
+msgid "Convert Cache Format"
+msgstr "تبدیل فرمت کش"
+
+msgid "Coordinates"
+msgstr "مختصات"
+
+msgid "Coordinates representation"
+msgstr "نمایندگی مختصات"
+
+msgid "Coordinates: %s"
+msgstr "مختصات: %s"
+
+msgid "Copy"
+msgstr "کپی کنید"
+
+msgid "Copy TID's to clipboard"
+msgstr "TID ها را در کلیپ بورد کپی کنید"
+
+msgid "Copy coordinates"
+msgstr "کپی مختصات"
+
+msgid "Copy description"
+msgstr "توضیحات را کپی کنید"
+
+msgid "Copy tiles from selection to folder"
+msgstr "کاشی ها را از انتخابی به پوشه دیگر کپی کنید"
+
+msgid "Copying"
+msgstr "کپی کردن"
+
+msgid "Course"
+msgstr "دوره"
+
+msgid "Course:"
+msgstr "دوره:"
+
+msgid "Create Shortcut"
+msgstr "ایجاد میانبر"
+
+msgid "Create georeferencing file:"
+msgstr "ایجاد فایل ارجاع جغرافیایی:"
+
+msgid "Create new placemark"
+msgstr "مکان نشان جدید ایجاد کنید"
+
+msgid "Create placemark"
+msgstr "مکان نشان ایجاد کنید"
+
+msgid "Current Altitude by GTOPO30 (~1 km accuracy)"
+msgstr "ارتفاع فعلی توسط GTOPO30 (~1 کیلومتر دقت)"
+
+msgid "Current Altitude by SRTM3 (~90 m accuracy)"
+msgstr "ارتفاع فعلی توسط SRTM3 (~90 متر دقت)"
+
+msgid "Current Zoom"
+msgstr "بزرگنمایی فعلی"
+
+msgid "Current speed, km/h:"
+msgstr "سرعت فعلی، کیلومتر در ساعت:"
+
+msgid "Current zoom"
+msgstr "بزرگنمایی فعلی"
+
+msgid "Custom HTTP Headers:"
+msgstr "هدرهای سفارشی HTTP:"
+
+msgid "DBMS"
+msgstr "DBMS"
+
+msgid "DBMS (Native driver)"
+msgstr "DBMS (درایور بومی)"
+
+msgid "DBMS (ODBC driver)"
+msgstr "DBMS (درایور ODBC)"
+
+msgid "DBMS root:"
+msgstr "ریشه DBMS:"
+
+msgid "DD+RC"
+msgstr "DD+RC"
+
+msgid "Data truncation occured because of external tile storage misconfiguration"
+msgstr "قطع داده ها به دلیل پیکربندی نادرست ذخیره سازی کاشی خارجی رخ داده است"
+
+msgid "Database type"
+msgstr "نوع پایگاه داده"
+
+msgid "Decompile"
+msgstr "دیکامپایل کنید"
+
+msgid "Default cache type"
+msgstr "نوع حافظه پنهان پیش فرض"
+
+msgid "Define hotkey"
+msgstr "کلید میانبر را تعریف کنید"
+
+msgid "Delete"
+msgstr "حذف کنید"
+
+msgid "Delete Category"
+msgstr "حذف دسته"
+
+msgid "Delete Overlay Layer Tile from Cache"
+msgstr "کاشی لایه پوششی را از کش حذف کنید"
+
+msgid "Delete Placemark"
+msgstr "علامت مکان را حذف کنید"
+
+msgid "Delete Point"
+msgstr "حذف نقطه"
+
+msgid "Delete Primary Map Tile from Cache (Del+MLeft)"
+msgstr "حذف کاشی نقشه اصلی از حافظه پنهان (Del+MLeft)"
+
+msgid "Delete Track"
+msgstr "حذف آهنگ"
+
+msgid "Delete both"
+msgstr "هر دو را حذف کنید"
+
+msgid "Delete empty tiles"
+msgstr "کاشی های خالی را حذف کنید"
+
+msgid "Delete from Favorites: '%s'?"
+msgstr "از موارد دلخواه حذف شود: '%s'؟"
+
+msgid "Delete hidden placemarks"
+msgstr "مکان مارک های پنهان را حذف کنید"
+
+msgid "Delete only tiles of size, bytes:"
+msgstr "فقط کاشی های اندازه، بایت را حذف کنید:"
+
+msgid "Delete selected placemark"
+msgstr "علامت مکان انتخابی را حذف کنید"
+
+msgid "Delete target"
+msgstr "هدف را حذف کنید"
+
+msgid "Delete the database"
+msgstr "پایگاه داده را حذف کنید"
+
+msgid "Delete tiles"
+msgstr "حذف کاشی ها"
+
+msgid "Delete tne"
+msgstr "حذف کنید"
+
+msgid "Deleted total:"
+msgstr "کل حذف شده:"
+
+msgid "Deleting"
+msgstr "در حال حذف"
+
+msgid "Deleting:"
+msgstr "حذف:"
+
+msgid "Description:"
+msgstr "توضیحات:"
+
+msgid ""
+"Description:<br>\n"
+"%s"
+msgstr ""
+"توضیحات:<br>\n"
+"%s"
+
+msgid "Dest Cache"
+msgstr "حافظه پنهان مقصد"
+
+msgid "Detalize route by bicycle (Fastest) with yournavigation.org"
+msgstr "با yournavigation.org مسیر با دوچرخه (سریعترین) را جزئی کنید"
+
+msgid "Detalize route by bicycle (Shortest) with yournavigation.org"
+msgstr "با yournavigation.org مسیر با دوچرخه (کوتاهترین) را جزئی کنید"
+
+msgid "Detalize route by car (Fastest) with yournavigation.org"
+msgstr "جزئیات مسیر با ماشین (سریعترین) با yournavigation.org"
+
+msgid "Detalize route by car (Shortest) with yournavigation.org"
+msgstr "جزئیات مسیر با ماشین (کوتاهترین) با yournavigation.org"
+
+msgid "Device timeout (sec)"
+msgstr "مهلت زمانی دستگاه (ثانیه)"
+
+msgid "Difference (NOT)"
+msgstr "تفاوت (نه)"
+
+msgid "DigitalGlobe (Catalogservice)"
+msgstr "DigitalGlobe (سرویس کاتالوگ)"
+
+msgid "Direct Copy"
+msgstr "کپی مستقیم"
+
+msgid "Direct tiles copy (without any modifications)"
+msgstr "کپی مستقیم کاشی (بدون هیچ گونه تغییر)"
+
+msgid "Directory %0:s not exist"
+msgstr "دایرکتوری %0:s وجود ندارد"
+
+msgid "Disable"
+msgstr "غیر فعال کردن"
+
+msgid "Disable or enable GPS"
+msgstr "GPS را غیرفعال یا فعال کنید"
+
+msgid "Disabled by Zmp"
+msgstr "توسط Zmp غیرفعال شده است"
+
+msgid "Disabled by map params"
+msgstr "توسط پارامترهای نقشه غیرفعال شد"
+
+msgid "Displayed Main Map"
+msgstr "نمایش نقشه اصلی"
+
+msgid "Distance"
+msgstr "فاصله"
+
+msgid "Distance #2, km:"
+msgstr "مسافت شماره 2، کیلومتر:"
+
+msgid "Distance Calculation"
+msgstr "محاسبه فاصله"
+
+msgid "Distance calculation"
+msgstr "محاسبه فاصله"
+
+msgid "Distance representation"
+msgstr "نمایندگی از راه دور"
+
+msgid "Distance to placemark"
+msgstr "فاصله تا علامت مکان"
+
+msgid "Distance to placemark:"
+msgstr "فاصله تا علامت مکان:"
+
+msgid "Distance, km:"
+msgstr "فاصله، کیلومتر:"
+
+msgid "Distance, m"
+msgstr "فاصله، m"
+
+msgid "Distance:"
+msgstr "فاصله:"
+
+msgid "Do not close this window after start"
+msgstr "پس از شروع این پنجره را نبندید"
+
+msgid "Do not close this window when finish"
+msgstr "پس از اتمام این پنجره را نبندید"
+
+msgid "Don't store references to non-existent tiles"
+msgstr "ارجاع به کاشی های موجود را ذخیره نکنید"
+
+msgid "Don't transform tiles to Geographic projection"
+msgstr "کاشی ها را به طرح ریزی جغرافیایی تبدیل نکنید"
+
+msgid "Double Free: Object is olready deleted!"
+msgstr "Double Free: شیء قبلاً حذف شده است!"
+
+msgid "Down"
+msgstr "پایین"
+
+msgid "Download"
+msgstr "دانلود کنید"
+
+msgid "Download Enabled"
+msgstr "دانلود فعال شد"
+
+msgid "Download Overlay Layer Tile to Cache"
+msgstr "کاشی لایه پوشش را در حافظه پنهان دانلود کنید"
+
+msgid "Download Primary Map Tile to Cache (Ins+MLeft)"
+msgstr "دانلود کاشی نقشه اولیه در حافظه پنهان (Ins+MLeft)"
+
+msgid "Download Tiles"
+msgstr "کاشی ها را دانلود کنید"
+
+msgid "Download completed"
+msgstr "دانلود تکمیل شد"
+
+msgid ""
+"Download completed successfully. You can update the program manually from "
+"file: %s"
+msgstr ""
+"دانلود با موفقیت انجام شد. می توانید برنامه را به صورت دستی از فایل: %s به "
+"روز کنید"
+
+msgid "Download enabled"
+msgstr "دانلود فعال شد"
+
+msgid "Download error. Error code %d"
+msgstr "خطای دانلود. کد خطا %d"
+
+msgid "Download error. Status code %d"
+msgstr "خطای دانلود. کد وضعیت %d"
+
+msgid "Download error. Unknown status code %d"
+msgstr "خطای دانلود. کد وضعیت ناشناخته %d"
+
+msgid "Download next tile if no response"
+msgstr "در صورت عدم پاسخ، کاشی بعدی را دانلود کنید"
+
+msgid "Download progress:"
+msgstr "پیشرفت دانلود:"
+
+msgid "Download session (*.sls)|*.sls"
+msgstr "دانلود جلسه (*.sls)|*.sls"
+
+msgid "Download state:"
+msgstr "وضعیت دانلود:"
+
+msgid "Download tiles off-screen"
+msgstr "کاشی های خارج از صفحه را دانلود کنید"
+
+msgid "Downloaded"
+msgstr "دانلود شد"
+
+msgid "Downloaded total:"
+msgstr "کل دانلود شده:"
+
+msgid "Downloading"
+msgstr "در حال دانلود"
+
+msgid "Downloading with overwrite..."
+msgstr "دانلود با رونویسی..."
+
+msgid "Downloading..."
+msgstr "در حال دانلود..."
+
+msgid "EarthSlicer cache folder:"
+msgstr "پوشه کش EarthSlicer:"
+
+msgid "Edit"
+msgstr "ویرایش کنید"
+
+msgid "Edit / Apply on double click"
+msgstr "ویرایش / اعمال با دوبار کلیک"
+
+msgid "Edit Category"
+msgstr "ویرایش دسته"
+
+msgid "Edit Hotkey"
+msgstr "کلید میانبر را ویرایش کنید"
+
+msgid "Edit Last Selection"
+msgstr "ویرایش آخرین انتخاب"
+
+msgid "Edit Marks Database"
+msgstr "ویرایش پایگاه داده علائم"
+
+msgid "Edit Path"
+msgstr "ویرایش مسیر"
+
+msgid "Edit Placemark"
+msgstr "علامت مکان را ویرایش کنید"
+
+msgid "Edit Polygon"
+msgstr "ویرایش چند ضلعی"
+
+msgid "Edit selected placemark"
+msgstr "مکان علامت انتخابی را ویرایش کنید"
+
+msgid "Edit the database"
+msgstr "پایگاه داده را ویرایش کنید"
+
+msgid "Elapsed time: %s"
+msgstr "زمان سپری شده: %s"
+
+msgid "Elevation Info"
+msgstr "اطلاعات ارتفاع"
+
+msgid "Empty GUID"
+msgstr "GUID خالی"
+
+msgid "Empty ZMP file name"
+msgstr "نام فایل ZMP را خالی کنید"
+
+msgid "Empty script"
+msgstr "اسکریپت خالی"
+
+msgid "Empty server response"
+msgstr "پاسخ سرور خالی"
+
+msgid "Empty tile samples do not exist for this map"
+msgstr "نمونه‌های کاشی خالی برای این نقشه وجود ندارد"
+
+msgid "Enable the following map types:"
+msgstr "انواع نقشه های زیر را فعال کنید:"
+
+msgid "Enter comma-separated MNC, MCC, LAC, CellID (example: 02,250,7718,11942)"
+msgstr "MNC، MCC، LAC، CellID جدا شده با کاما را وارد کنید (مثال: 02,250,7718,11942)"
+
+msgid "Enter parameters"
+msgstr "پارامترها را وارد کنید"
+
+msgid "Error"
+msgstr "خطا"
+
+msgid "Error at script bytecode loading"
+msgstr "خطا در بارگیری بایت کد اسکریپت"
+
+msgid "Error code:"
+msgstr "کد خطا:"
+
+msgid "Error communicating with device"
+msgstr "خطا در برقراری ارتباط با دستگاه"
+
+msgid "Error connecting to server"
+msgstr "خطا در اتصال به سرور"
+
+msgid "Error in geographic coordinates"
+msgstr "خطا در مختصات جغرافیایی"
+
+msgid "Error in parameters!"
+msgstr "خطا در پارامترها!"
+
+msgid "Error in projection \"%0:s\" of the map"
+msgstr "خطا در طرح \"%0:s\" نقشه"
+
+msgid "Error opening port!"
+msgstr "خطا در باز کردن پورت!"
+
+msgid "Error parsing coordinates: Lat=%s Lon=%s"
+msgstr "خطا در تجزیه مختصات: Lat=%s Lon=%s"
+
+msgid "Error while saving!"
+msgstr "خطا هنگام ذخیره!"
+
+msgid "Every map part must have height less than %0:d but exist %1:d"
+msgstr "هر قسمت نقشه باید ارتفاع کمتر از %0:d داشته باشد اما %1:d وجود داشته باشد"
+
+msgid "Every map part must have height more than %0:d but exist %1:d"
+msgstr "هر قسمت نقشه باید بیش از %0:d ارتفاع داشته باشد اما %1:d وجود داشته باشد"
+
+msgid "Every map part must have width less than %0:d but exist %1:d"
+msgstr "هر قسمت نقشه باید عرض کمتر از %0:d داشته باشد اما %1:d وجود داشته باشد"
+
+msgid "Every map part must have width more than %0:d but exist %1:d"
+msgstr "هر قسمت نقشه باید بیش از %0:d عرض داشته باشد اما %1:d وجود داشته باشد"
+
+msgid "Exclusive or (XOR)"
+msgstr "انحصاری یا (XOR)"
+
+msgid "Export"
+msgstr "صادرات"
+
+msgid "Export Placemark"
+msgstr "علامت مکان صادر کنید"
+
+msgid "Export Placemarks"
+msgstr "صادر کردن مکان‌ها"
+
+msgid "Export all placemarks and all categories"
+msgstr "همه مکان‌ها و همه دسته‌ها را صادر کنید"
+
+msgid "Export placemarks from selected category"
+msgstr "نشانک‌های مکان را از دسته انتخابی صادر کنید"
+
+msgid "Export selected placemark"
+msgstr "نشانک مکان انتخابی را صادر کنید"
+
+msgid "Export selection to format"
+msgstr "صادرات انتخاب به قالب"
+
+msgid "Export selection to format:"
+msgstr "صادرات انتخاب به قالب:"
+
+msgid "Export visible placemarks"
+msgstr "نشانک های قابل مشاهده را صادر کنید"
+
+msgid "Extention:"
+msgstr "گسترش:"
+
+msgid "External tile storage is readonly"
+msgstr "فضای ذخیره‌سازی کاشی خارجی فقط خواندنی است"
+
+msgid "Failed to save to external tile storage: error "
+msgstr "ذخیره در حافظه خارجی کاشی انجام نشد: خطا"
+
+msgid "Favorite maps/layers"
+msgstr "نقشه ها/لایه های مورد علاقه"
+
+msgid "Favorites"
+msgstr "موارد دلخواه"
+
+msgid "Favorites Manager"
+msgstr "مدیر مورد علاقه"
+
+msgid "File"
+msgstr "فایل"
+
+msgid ""
+"File %0:s is available on disk.\n"
+"Replace?"
+msgstr ""
+"فایل %0:s روی دیسک موجود است.\n"
+"جایگزین شود؟"
+
+msgid "File %0:s not exist"
+msgstr "فایل %0:s وجود ندارد"
+
+msgid "File %0:s not found"
+msgstr "فایل %0:s یافت نشد"
+
+msgid "File name"
+msgstr "نام فایل"
+
+msgid "Files %0:s and %1:s have the same GUID"
+msgstr "فایل‌های %0:s و %1:s دارای GUID یکسان هستند"
+
+msgid "Fill From "
+msgstr "پر کردن از"
+
+msgid "Fill:"
+msgstr "پر کردن:"
+
+msgid "FillDates"
+msgstr "FillDates"
+
+msgid "Filter"
+msgstr "فیلتر کنید"
+
+msgid "Filter: \"%s\" (%d)"
+msgstr "فیلتر: \"%s\" (%d)"
+
+msgid "Finished"
+msgstr "تمام شد"
+
+msgid "Fit to Screen"
+msgstr "متناسب با صفحه نمایش"
+
+msgid "Fit to screen"
+msgstr "متناسب با صفحه نمایش"
+
+msgid "Follow GPS Position"
+msgstr "موقعیت GPS را دنبال کنید"
+
+msgid "Font"
+msgstr "فونت"
+
+msgid "Font size"
+msgstr "اندازه فونت"
+
+msgid "For"
+msgstr "برای"
+
+msgid "Format:"
+msgstr "قالب:"
+
+msgid "From Archive"
+msgstr "از آرشیو"
+
+msgid "From Folder"
+msgstr "از پوشه"
+
+msgid "From Layer"
+msgstr "از لایه"
+
+msgid "From Map"
+msgstr "از نقشه"
+
+msgid "From mains"
+msgstr "از برق"
+
+msgid "From zoom:"
+msgstr "از زوم:"
+
+msgid "Full Description"
+msgstr "توضیحات کامل"
+
+msgid "GB"
+msgstr "گیگابایت"
+
+msgid "GPS Marker"
+msgstr "نشانگر GPS"
+
+msgid "GPS On/Off"
+msgstr "GPS روشن/خاموش"
+
+msgid "GPS origin misconfiguration: unknown mode %d"
+msgstr "پیکربندی اشتباه مبدا GPS: حالت ناشناخته %d"
+
+msgid "GPS type"
+msgstr "نوع GPS"
+
+msgid "Gamma"
+msgstr "گاما"
+
+msgid "GenShtab Maps Boundaries"
+msgstr "مرزهای نقشه های GenShtab"
+
+msgid "Generate"
+msgstr "ایجاد کنید"
+
+msgid "Generate Lower Zooms for Selection"
+msgstr "زوم های کمتری برای انتخاب ایجاد کنید"
+
+msgid "Generate each zoom from previous one"
+msgstr "هر بزرگنمایی را از قبلی ایجاد کنید"
+
+msgid "Generating upper zooms"
+msgstr "ایجاد زوم های بالا"
+
+msgid "Genshtab Map boundaries:"
+msgstr "محدوده نقشه گشتاب:"
+
+msgid "Genshtab Map names"
+msgstr "اسامی نقشه گشتاب"
+
+msgid "Genshtab boundary name"
+msgstr "نام مرز گشتاب"
+
+msgid "GeoCacher"
+msgstr "GeoCacher"
+
+msgid "GeoCacher root folder:"
+msgstr "پوشه ریشه GeoCacher:"
+
+msgid "Geographic (Latitude/Longitude) / WGS84 / EPSG:4326"
+msgstr "جغرافیایی (طول و عرض جغرافیایی) / WGS84 / EPSG: 4326"
+
+msgid "Geographic Coordinates"
+msgstr "مختصات جغرافیایی"
+
+msgid "GetURLScript.txt"
+msgstr "GetURLScript.txt"
+
+msgid "GetUrlScript"
+msgstr "GetUrlScript"
+
+msgid "GetUrlScript.txt"
+msgstr "GetUrlScript.txt"
+
+msgid "GetX:"
+msgstr "GetX:"
+
+msgid "GetY:"
+msgstr "GetY:"
+
+msgid "GetZ:"
+msgstr "GetZ:"
+
+msgid "GlobalMapper Bing"
+msgstr "GlobalMapper Bing"
+
+msgid "GlobalMapper Tiles"
+msgstr "کاشی های GlobalMapper"
+
+msgid "GlobalMapper Tiles (GMT) cache folder:"
+msgstr "پوشه کش GlobalMapper Tiles (GMT):"
+
+msgid "Go to"
+msgstr "رفتن به"
+
+msgid "Go to selected object"
+msgstr "به شی انتخاب شده بروید"
+
+msgid "Go to..."
+msgstr "رفتن به..."
+
+msgid "GoogleEarth Terrain"
+msgstr "GoogleEarth Terrain"
+
+msgid "GoogleEarth cache folder:"
+msgstr "پوشه کش GoogleEarth:"
+
+msgid "GoogleMV cache folder:"
+msgstr "پوشه کش GoogleMV:"
+
+msgid "Grid line labels"
+msgstr "برچسب های خط شبکه"
+
+msgid "Grids"
+msgstr "شبکه ها"
+
+msgid "Group"
+msgstr "گروه"
+
+msgid "HTTP %d Bad Request"
+msgstr "HTTP %d درخواست بد"
+
+msgid "HTTP %d No Content"
+msgstr "HTTP %d بدون محتوا"
+
+msgid "HTTP %d Not Found"
+msgstr "HTTP %d یافت نشد"
+
+msgid "HTTP %d Unknown Error"
+msgstr "HTTP %d خطای ناشناخته"
+
+msgid "Height:"
+msgstr "قد:"
+
+msgid "Hide"
+msgstr "پنهان کردن"
+
+msgid "Hide All"
+msgstr "پنهان کردن همه"
+
+msgid "Hide All Placemarks"
+msgstr "پنهان کردن همه مکان‌ها"
+
+msgid "Hide Scale Legend"
+msgstr "پنهان کردن افسانه مقیاس"
+
+msgid "Hide Status Bar"
+msgstr "پنهان کردن نوار وضعیت"
+
+msgid "Hide all placemarks"
+msgstr "پنهان کردن همه مکان‌ها"
+
+msgid "Hide non-selected layers"
+msgstr "لایه های انتخاب نشده را مخفی کنید"
+
+msgid "Hide placemarks"
+msgstr "مکان نشان ها را پنهان کنید"
+
+msgid "Hotkey"
+msgstr "کلید فوری"
+
+msgid "Hotkey in use. Please select another one"
+msgstr "کلید میانبر در حال استفاده لطفا یکی دیگر را انتخاب کنید"
+
+msgid "Hotkeys"
+msgstr "کلیدهای فوری"
+
+msgid "Hybrid"
+msgstr "هیبرید"
+
+msgid "Icon"
+msgstr "نماد"
+
+msgid "Icon parameters"
+msgstr "پارامترهای آیکون"
+
+msgid "Icon size"
+msgstr "اندازه آیکون"
+
+msgid "Icon size:"
+msgstr "اندازه آیکون:"
+
+msgid "Ignore *.tne"
+msgstr "نادیده گرفتن *.tne"
+
+msgid "Ignore paths"
+msgstr "مسیرها را نادیده بگیرید"
+
+msgid "Ignore placemarks"
+msgstr "مکان‌ها را نادیده بگیرید"
+
+msgid "Ignore polygons"
+msgstr "چند ضلعی ها را نادیده بگیرید"
+
+msgid "Image format:"
+msgstr "فرمت تصویر:"
+
+msgid "Image postprocessing"
+msgstr "پس پردازش تصویر"
+
+msgid "Image services"
+msgstr "خدمات تصویر"
+
+msgid "Images available"
+msgstr "تصاویر موجود"
+
+msgid "Images available (F6+MLeft)"
+msgstr "تصاویر موجود (F6+MLeft)"
+
+msgid "Import"
+msgstr "واردات"
+
+msgid "Import Parameters"
+msgstr "پارامترهای واردات"
+
+msgid ""
+"Import finished. Total processed: %d files. Successfull imported: %d files.\n"
+"Fit to screen the last imported item?"
+msgstr ""
+"واردات تمام شد کل پردازش شده: %d فایل. با موفقیت وارد شد: %d فایل.\n"
+"آیا برای نمایش آخرین مورد وارد شده مناسب است؟"
+
+msgid "Include alpha channel"
+msgstr "شامل کانال آلفا"
+
+msgid "Incorrect GUID: %0:s"
+msgstr "GUID نادرست: %0:s"
+
+msgid "Inertial Movement"
+msgstr "حرکت اینرسی"
+
+msgid "Info"
+msgstr "اطلاعات"
+
+msgid "Info.txt"
+msgstr "Info.txt"
+
+msgid "Input Vars"
+msgstr "متغیرهای ورودی"
+
+msgid "Interface"
+msgstr "رابط"
+
+msgid "Interface Options"
+msgstr "گزینه های رابط"
+
+msgid "Interface is nil"
+msgstr "رابط صفر است"
+
+msgid "Interface to external tile storage not implemented"
+msgstr "رابط ذخیره سازی کاشی خارجی اجرا نشده است"
+
+msgid "Internet"
+msgstr "اینترنت"
+
+msgid "Internet && Cache"
+msgstr "اینترنت && کش"
+
+msgid "Intersection (AND)"
+msgstr "تقاطع (AND)"
+
+msgid "Invalid Delete: Object is still have active interface ref's! (Ref count: %d)"
+msgstr "حذف نامعتبر: شی هنوز دارای ref رابط فعال است! (تعداد مراجع: %d)"
+
+msgid "Issue Tracker (http://sasgis.org/mantis)"
+msgstr "ردیاب مشکل (http://sasgis.org/mantis)"
+
+msgid "JNX raster map for Garmin"
+msgstr "نقشه شطرنجی JNX برای گارمین"
+
+msgid "JNX version:"
+msgstr "نسخه JNX:"
+
+msgid "JPEG quality:"
+msgstr "کیفیت JPEG:"
+
+msgid "Jpeg Import Parameters"
+msgstr "پارامترهای واردات Jpeg"
+
+msgid "KB"
+msgstr "کیلوبایت"
+
+msgid "KML (for Google Earth)"
+msgstr "KML (برای Google Earth)"
+
+msgid "KS+Storage"
+msgstr "KS+Storage"
+
+msgid "Kosmosnimki"
+msgstr "Kosmosnimki"
+
+msgid "Kosmosnimki (search.kosmosnimki.ru)"
+msgstr "Kosmosnimki (search.kosmosnimki.ru)"
+
+msgid "Language"
+msgstr "زبان"
+
+msgid "Last Selection"
+msgstr "آخرین انتخاب"
+
+msgid "Last name:"
+msgstr "نام خانوادگی:"
+
+msgid "Lat/Lon Grid"
+msgstr "شبکه Lat/Lon Grid"
+
+msgid "Lat/Lon grid:"
+msgstr "شبکه Lat/Lon:"
+
+msgid ""
+"Latitude of upper left corner must be less than \n"
+"latitude of lower right corner"
+msgstr ""
+"عرض جغرافیایی گوشه سمت چپ بالا باید کمتر از \n"
+"عرض جغرافیایی گوشه سمت راست پایین"
+
+msgid "Latitude-Longitude order"
+msgstr "ترتیب طول و عرض جغرافیایی"
+
+msgid "Latitude:"
+msgstr "عرض جغرافیایی:"
+
+msgid "Layer"
+msgstr "لایه"
+
+msgid "Layer Info"
+msgstr "اطلاعات لایه"
+
+msgid "Layer Settings"
+msgstr "تنظیمات لایه"
+
+msgid "Layers"
+msgstr "لایه ها"
+
+msgid "Layers (%d)"
+msgstr "لایه ها (%d)"
+
+msgid "Layers:"
+msgstr "لایه ها:"
+
+msgid "Length"
+msgstr "طول"
+
+msgid "Length: %s"
+msgstr "طول: %s"
+
+msgid "License"
+msgstr "مجوز"
+
+msgid "Line:"
+msgstr "خط:"
+
+msgid "List capacity out of bounds (%d)"
+msgstr "فهرست ظرفیت خارج از محدوده (%d)"
+
+msgid "List count out of bounds (%d)"
+msgstr "تعداد فهرست خارج از محدوده (%d)"
+
+msgid "List index out of bounds (%d)"
+msgstr "فهرست خارج از محدوده (%d)"
+
+msgid "Listings"
+msgstr "لیست ها"
+
+msgid "Load from File"
+msgstr "بارگیری از فایل"
+
+msgid "Local time"
+msgstr "به وقت محلی"
+
+msgid "Local time:"
+msgstr "زمان محلی:"
+
+msgid "Lock Toolbars"
+msgstr "قفل کردن نوار ابزار"
+
+msgid "Lock toolbars"
+msgstr "قفل کردن نوار ابزار"
+
+msgid ""
+"Longitude of upper left corner must be less than \n"
+"longitude of lower right corner"
+msgstr ""
+"طول گوشه بالا سمت چپ باید کمتر از \n"
+"طول جغرافیایی گوشه سمت راست پایین"
+
+msgid "Longitude:"
+msgstr "طول جغرافیایی:"
+
+msgid "Low Resolution too"
+msgstr "وضوح پایین نیز"
+
+msgid "Lower right corner"
+msgstr "گوشه سمت راست پایین"
+
+msgid "MB"
+msgstr "مگابایت"
+
+msgid "MBTiles 1.2 (SQLite3)"
+msgstr "MBTiles 1.2 (SQLite3)"
+
+msgid "MOBAC cache folder:"
+msgstr "پوشه کش MOBAC:"
+
+msgid "Main"
+msgstr "اصلی"
+
+msgid "Main Menu"
+msgstr "منوی اصلی"
+
+msgid "Make Polygon"
+msgstr "چند ضلعی درست کنید"
+
+msgid "Make Polygon by RosReestr (F8+MLeft)"
+msgstr "ساخت چند ضلعی توسط RosReestr (F8+MLeft)"
+
+msgid "Make TileMill compatible structure"
+msgstr "ساختن ساختار سازگار با TileMill"
+
+msgid "Make by Placemark"
+msgstr "ساخت توسط Placemark"
+
+msgid "Make subfolder with map path name"
+msgstr "پوشه فرعی با نام مسیر نقشه بسازید"
+
+msgid "Manage"
+msgstr "مدیریت کنید"
+
+msgid "Manage Selection"
+msgstr "مدیریت انتخاب"
+
+msgid "Map"
+msgstr "نقشه"
+
+msgid "Map Info"
+msgstr "اطلاعات نقشه"
+
+msgid "Map Name"
+msgstr "نام نقشه"
+
+msgid "Map Name:"
+msgstr "نام نقشه:"
+
+msgid "Map Original Projection (from zmp)"
+msgstr "نقشه طرح اصلی (از zmp)"
+
+msgid "Map Settings"
+msgstr "تنظیمات نقشه"
+
+msgid "Map Settings:"
+msgstr "تنظیمات نقشه:"
+
+msgid "Map Storage Info"
+msgstr "اطلاعات ذخیره سازی نقشه"
+
+msgid "Map Version:"
+msgstr "نسخه نقشه:"
+
+msgid "Map enabled"
+msgstr "نقشه فعال شد"
+
+msgid ""
+"Map has unknown projection (EPSG=%d).\n"
+"Do you want to set the projection manually?"
+msgstr ""
+"نقشه دارای طرح ریزی ناشناخته است (EPSG=%d).\n"
+"آیا می خواهید پروجکشن را به صورت دستی تنظیم کنید؟"
+
+msgid "Map/Overlay layer:"
+msgstr "لایه نقشه/روکش:"
+
+msgid "Map:"
+msgstr "نقشه:"
+
+msgid "Maps"
+msgstr "نقشه ها"
+
+msgid "Maps (%d)"
+msgstr "نقشه‌ها (%d)"
+
+msgid "Mark Existing Tiles"
+msgstr "علامت گذاری کاشی های موجود"
+
+msgid "Mark Info"
+msgstr "علامت گذاری اطلاعات"
+
+msgid "Mark Nonexistent Tiles"
+msgstr "کاشی های موجود را علامت گذاری کنید"
+
+msgid "MarkSystemConfig: Item #%d Database GUID read error!"
+msgstr "MarkSystemConfig: مورد #%d خطای خواندن GUID پایگاه داده!"
+
+msgid "MarkSystemConfig: Item #%d Impl GUID read error!"
+msgstr "MarkSystemConfig: مورد #%d خطای خواندن Impl GUID!"
+
+msgid "MarkSystemConfig: Item #%d has unknown Impl GUID: %s"
+msgstr "MarkSystemConfig: مورد #%d دارای GUID Impl ناشناخته است: %s"
+
+msgid "MarkSystemConfig: Item #%d has unknown Impl interface!"
+msgstr "MarkSystemConfig: مورد #%d دارای رابط Impl ناشناخته است!"
+
+msgid "Marks Parameters"
+msgstr "پارامترها را علامت گذاری می کند"
+
+msgid "Max concurrent http(s)-requests number:"
+msgstr "حداکثر تعداد درخواست‌های http(s) همزمان:"
+
+msgid "Max volume size, Mb"
+msgstr "حداکثر اندازه حجم، Mb"
+
+msgid "Max.speed, km/h:"
+msgstr "حداکثر سرعت، کیلومتر در ساعت:"
+
+msgid "Maximum number of track points:"
+msgstr "حداکثر تعداد امتیاز آهنگ:"
+
+msgid "Maximum speed"
+msgstr "حداکثر سرعت"
+
+msgid "Menu"
+msgstr "منو"
+
+msgid "Mercator / Google Maps (Sphere Radius 6378137) / EPSG:3785"
+msgstr "Mercator / Google Maps (Sphere Radius 6378137) / EPSG:3785"
+
+msgid "Mercator / WGS84 / EPSG:3395"
+msgstr "Mercator / WGS84 / EPSG:3395"
+
+msgid "Merge Polygons"
+msgstr "چند ضلعی ها را ادغام کنید"
+
+msgid "Merge failed!"
+msgstr "ادغام ناموفق بود!"
+
+msgid "Merge polygons"
+msgstr "چند ضلعی ها را ادغام کنید"
+
+msgid ""
+"Merge process completed successfully!\n"
+"Result contains %d polygon(s) with %d hole(s)"
+msgstr ""
+"فرآیند ادغام با موفقیت انجام شد!\n"
+"نتیجه شامل %d چند ضلعی با %d سوراخ (ها) است"
+
+msgid "Meteor-M1"
+msgstr "Meteor-M1"
+
+msgid "Minimap opacity"
+msgstr "کدورت نقشه کوچک"
+
+msgid "Minimize"
+msgstr "به حداقل رساندن"
+
+msgid "Minimize to tray"
+msgstr "سینی را به حداقل برسانید"
+
+msgid "Mobile Atlas Creator (MOBAC)"
+msgstr "سازندگان اطلس موبایل (MOBAC)"
+
+msgid "Modify"
+msgstr "اصلاح کنید"
+
+msgid "MongoDB"
+msgstr "MongoDB"
+
+msgid "Most likely you've been banned by the server!"
+msgstr "به احتمال زیاد توسط سرور بن شده اید!"
+
+msgid "Mouse wheel"
+msgstr "چرخ ماوس"
+
+msgid "Move"
+msgstr "حرکت کنید"
+
+msgid "Move Down"
+msgstr "حرکت به پایین"
+
+msgid "Move Up"
+msgstr "حرکت به بالا"
+
+msgid "Move selected item Down (Shift + Down Arrow)"
+msgstr "انتقال آیتم انتخابی به پایین (Shift + پیکان پایین)"
+
+msgid "Move selected item Up (Shift + Up Arrow)"
+msgstr "انتقال آیتم انتخابی به بالا (Shift + پیکان بالا)"
+
+msgid "My Marks"
+msgstr "نشانه های من"
+
+msgid "Name"
+msgstr "نام"
+
+msgid "Name (on the list)"
+msgstr "نام (در لیست)"
+
+msgid "Name:"
+msgstr "نام:"
+
+msgid "Name: %s"
+msgstr "نام: %s"
+
+msgid "Native cache folder:"
+msgstr "پوشه کش بومی:"
+
+msgid "Navigate to Placemark"
+msgstr "به علامت مکان بروید"
+
+msgid "Navigate to selected placemark"
+msgstr "به مکان علامت انتخاب شده بروید"
+
+msgid "Navigation Arrow"
+msgstr "پیکان ناوبری"
+
+msgid "Network operations timeout, ms"
+msgstr "مهلت زمانی عملیات شبکه، ms"
+
+msgid "New Category"
+msgstr "دسته جدید"
+
+msgid "Next map with tile"
+msgstr "نقشه بعدی با کاشی"
+
+msgid "Next version"
+msgstr "نسخه بعدی"
+
+msgid "Nice"
+msgstr "خوبه"
+
+msgid "Night Mode (Color Inversion)"
+msgstr "حالت شب (وارونگی رنگ)"
+
+msgid "Night mode (color inversion)"
+msgstr "حالت شب (وارونگی رنگ)"
+
+msgid "Nightly (testing)"
+msgstr "شبانه (تست)"
+
+msgid "No"
+msgstr "خیر"
+
+msgid "No GPS receiver found"
+msgstr "گیرنده GPS یافت نشد"
+
+msgid "No one polygon selected!"
+msgstr "هیچ چند ضلعی انتخاب نشده است!"
+
+msgid "No source for Fly-on-Track mode"
+msgstr "منبعی برای حالت Fly-on-Track وجود ندارد"
+
+msgid "No space available at external tile storage"
+msgstr "فضایی در فضای ذخیره سازی کاشی خارجی موجود نیست"
+
+msgid "No write access to tile storage"
+msgstr "دسترسی نوشتن به فضای ذخیره‌سازی کاشی وجود ندارد"
+
+msgid "North"
+msgstr "شمال"
+
+msgid "Not found \"params.txt\" in zmp"
+msgstr "\"params.txt\" در zmp یافت نشد"
+
+msgid "Not found PARAMS section in zmp"
+msgstr "بخش PARAMS در zmp یافت نشد"
+
+msgid "Nothing found on current map."
+msgstr "در نقشه فعلی چیزی یافت نشد."
+
+msgid "Nothing to copy: URL is empty!"
+msgstr "چیزی برای کپی وجود ندارد: URL خالی است!"
+
+msgid "Nothing to delete - GPS track is empty."
+msgstr "چیزی برای حذف وجود ندارد - مسیر GPS خالی است."
+
+msgid "Nothing to import!"
+msgstr "چیزی برای واردات نیست!"
+
+msgid "Number of rings"
+msgstr "تعداد حلقه"
+
+msgid "Number of tiles"
+msgstr "تعداد کاشی"
+
+msgid "Number of tiles to be cached in RAM"
+msgstr "تعداد کاشی هایی که باید در حافظه رم ذخیره شوند"
+
+msgid "Number of tiles: %0:sx%1:s (%2:s), size: %3:sx%4:s"
+msgstr "تعداد کاشی‌ها: %0:sx%1:s (%2:s)، اندازه: %3:sx%4:s"
+
+msgid "Numbers Format"
+msgstr "فرمت اعداد"
+
+msgid "OGF2 tiles format:"
+msgstr "فرمت کاشی های OGF2:"
+
+msgid "OGF2 tiles resolution:"
+msgstr "وضوح کاشی های OGF2:"
+
+msgid "Object is nil"
+msgstr "شیء صفر است"
+
+msgid "Odometer"
+msgstr "کیلومتر شمار"
+
+msgid "Odometer #2"
+msgstr "کیلومتر شمار شماره 2"
+
+msgid "Ogf2 map for SmartComGPS 1.5x"
+msgstr "نقشه Ogf2 برای SmartComGPS 1.5x"
+
+msgid "Old after days"
+msgstr "قدیمی بعد از روز"
+
+msgid "On change zoom draft"
+msgstr "در تغییر پیش نویس بزرگنمایی"
+
+msgid "On download"
+msgstr "در حال دانلود"
+
+msgid "On get from lower zoom"
+msgstr "از زوم کمتر دریافت کنید"
+
+msgid "On load from cache"
+msgstr "در بارگیری از حافظه پنهان"
+
+msgid "On projection change"
+msgstr "در مورد تغییر طرح"
+
+msgid "On-Line Help"
+msgstr "راهنما آنلاین"
+
+msgid "Online Help (http://sasgis.org/wikisasiya)"
+msgstr "راهنمای آنلاین (http://sasgis.org/wikisasiya)"
+
+msgid "Opacity"
+msgstr "کدورت"
+
+msgid "Opacity %"
+msgstr "شفافیت %"
+
+msgid "Opacity:"
+msgstr "کدورت:"
+
+msgid "Open Overlay Layer Tile Folder"
+msgstr "پوشه کاشی لایه پوشش را باز کنید"
+
+msgid "Open Primary Map Tile Folder"
+msgstr "پوشه اصلی نقشه کاشی را باز کنید"
+
+msgid "Open zmp"
+msgstr "zmp را باز کنید"
+
+msgid "Open..."
+msgstr "باز کن..."
+
+msgid "Options"
+msgstr "گزینه ها"
+
+msgid "Options..."
+msgstr "گزینه های ..."
+
+msgid "OruxMaps (SQLite3)"
+msgstr "OruxMaps (SQLite3)"
+
+msgid "OsmAnd+ Tiles"
+msgstr "OsmAnd+ کاشی"
+
+msgid "Other"
+msgstr "دیگر"
+
+msgid "Others"
+msgstr "دیگران"
+
+msgid "Outline color:"
+msgstr "رنگ طرح کلی:"
+
+msgid "Output format"
+msgstr "فرمت خروجی"
+
+msgid "Output format:"
+msgstr "فرمت خروجی:"
+
+msgid "Overlay layer:"
+msgstr "لایه روکش:"
+
+msgid "Overview Map"
+msgstr "نقشه نمای کلی"
+
+msgid "Overwrite existing tiles"
+msgstr "رونویسی کاشی های موجود"
+
+msgid "Overwrite if equal"
+msgstr "در صورت مساوی بازنویسی کنید"
+
+msgid "Overwrite old tiles"
+msgstr "رونویسی کاشی های قدیمی"
+
+msgid "PNG (Indexed Colors)"
+msgstr "PNG (رنگ های نمایه شده)"
+
+msgid "PNG (TrueColor + Alpha)"
+msgstr "PNG (TrueColor + Alpha)"
+
+msgid "PNG (TrueColor)"
+msgstr "PNG (TrueColor)"
+
+msgid "Packed cache for SAS4WinCE/SAS4Android"
+msgstr "کش بسته بندی شده برای SAS4WinCE/SAS4Android"
+
+msgid "Parameter"
+msgstr "پارامتر"
+
+msgid "Params"
+msgstr "پارامترها"
+
+msgid "Params.txt"
+msgstr "Params.txt"
+
+msgid "Parent submenu"
+msgstr "منوی فرعی والد"
+
+msgid "Parts count: %d"
+msgstr "تعداد قطعات: %d"
+
+msgid "Password"
+msgstr "رمز عبور"
+
+msgid "Password:"
+msgstr "رمز عبور:"
+
+msgid "Path %0:d"
+msgstr "مسیر %0:d"
+
+msgid "Path parameters"
+msgstr "پارامترهای مسیر"
+
+msgid "Path to Maps"
+msgstr "مسیر رسیدن به نقشه ها"
+
+msgid "Path to Marks database"
+msgstr "مسیر به پایگاه داده Marks"
+
+msgid "Path to MediaData"
+msgstr "مسیر به MediaData"
+
+msgid "Path to Terrain data"
+msgstr "مسیر به داده های زمین"
+
+msgid "Path to gps tracks"
+msgstr "مسیر دسترسی به آهنگ های GPS"
+
+msgid "Path to map scan DB"
+msgstr "مسیر اسکن نقشه DB"
+
+msgid "Path to marks icon"
+msgstr "نماد مسیر به علامت‌ها"
+
+msgid "Path to user data"
+msgstr "مسیر دسترسی به داده های کاربر"
+
+msgid "Path:"
+msgstr "مسیر:"
+
+msgid "Pathname to Tile in Cache"
+msgstr "نام مسیر به کاشی در حافظه پنهان"
+
+msgid "Paths"
+msgstr "مسیرها"
+
+msgid "Pause"
+msgstr "مکث کنید"
+
+msgid "Pause, ms:"
+msgstr "مکث، ms:"
+
+msgid "Paused by user..."
+msgstr "توسط کاربر متوقف شد..."
+
+msgid "Paused... (%0:s)"
+msgstr "متوقف شد... (%0:s)"
+
+msgid "Perimeter"
+msgstr "محیط"
+
+msgid "Perimeter: %s"
+msgstr "محیط: %s"
+
+msgid "Pixel"
+msgstr "پیکسل"
+
+msgid "PlaceMarks"
+msgstr "علامت‌های مکان"
+
+msgid "Placemark"
+msgstr "علامت مکان"
+
+msgid "Placemark %0:d"
+msgstr "نشان مکان %0:d"
+
+msgid "Placemark Categories"
+msgstr "دسته بندی نشان مکان"
+
+msgid "Placemark Export"
+msgstr "صادرات نشان مکان"
+
+msgid "Placemark Info"
+msgstr "اطلاعات نشان مکان"
+
+msgid "Placemark Manager"
+msgstr "مدیر علامت مکان"
+
+msgid "Placemark Names"
+msgstr "نام های مکان نشان"
+
+msgid "Placemark manager"
+msgstr "مدیر علامت مکان"
+
+msgid "Placemark parameters"
+msgstr "پارامترهای علامت مکان"
+
+msgid "Placemarks"
+msgstr "مکان‌ها"
+
+msgid "Play"
+msgstr "بازی کنید"
+
+msgid "Please select at least one map"
+msgstr "لطفا حداقل یک نقشه را انتخاب کنید"
+
+msgid "Please select at least one map or overlay layer"
+msgstr "لطفاً حداقل یک نقشه یا لایه همپوشانی را انتخاب کنید"
+
+msgid "Please select at least one region"
+msgstr "لطفاً حداقل یک منطقه را انتخاب کنید"
+
+msgid "Please select at least one zoom"
+msgstr "لطفاً حداقل یک بزرگنمایی را انتخاب کنید"
+
+msgid "Please select at one placemark type"
+msgstr "لطفاً در یک نوع مکان مکان انتخاب کنید"
+
+msgid "Please select map or layer"
+msgstr "لطفاً نقشه یا لایه را انتخاب کنید"
+
+msgid "Please select output file"
+msgstr "لطفا فایل خروجی را انتخاب کنید"
+
+msgid "Please select output folder"
+msgstr "لطفا پوشه خروجی را انتخاب کنید"
+
+msgid "Please wait, download in progress..."
+msgstr "لطفا صبر کنید، دانلود در حال انجام است..."
+
+msgid "Please wait..."
+msgstr "لطفا صبر کنید..."
+
+msgid "Please, select at least one polygon!"
+msgstr "لطفاً حداقل یک چند ضلعی را انتخاب کنید!"
+
+msgid "Please, select category with at least one polygon!"
+msgstr "لطفاً دسته ای را با حداقل یک چندضلعی انتخاب کنید!"
+
+msgid "Please, select output file first!"
+msgstr "لطفا ابتدا فایل خروجی را انتخاب کنید!"
+
+msgid "Please, select zoom/coordinates or at least one Layer or Map first!"
+msgstr "لطفاً ابتدا زوم/مختصات یا حداقل یک لایه یا نقشه را انتخاب کنید!"
+
+msgid "Pointer size:"
+msgstr "اندازه اشاره گر:"
+
+msgid "Points count: %d"
+msgstr "تعداد امتیاز: %d"
+
+msgid "Polygon %0:d"
+msgstr "چند ضلعی %0:d"
+
+msgid "Polygon isn't selected"
+msgstr "چند ضلعی انتخاب نشده است"
+
+msgid "Polygon parameters"
+msgstr "پارامترهای چند ضلعی"
+
+msgid "Polygonal Selection"
+msgstr "انتخاب چند ضلعی"
+
+msgid "Polygons"
+msgstr "چند ضلعی ها"
+
+msgid "Polyline Selection"
+msgstr "انتخاب چند خط"
+
+msgid "Pool Disabled - Can't acquire db: %s"
+msgstr "Pool Disabled - نمی توان db را بدست آورد: %s"
+
+msgid "Press Ctrl and click on polygon to add one..."
+msgstr "Ctrl را فشار دهید و روی چند ضلعی کلیک کنید تا یکی اضافه شود..."
+
+msgid "Previous Selection"
+msgstr "انتخاب قبلی"
+
+msgid "Previous map with tile"
+msgstr "نقشه قبلی با کاشی"
+
+msgid "Previous version"
+msgstr "نسخه قبلی"
+
+msgid "Primary Map Tile"
+msgstr "کاشی نقشه اولیه"
+
+msgid "Primary color"
+msgstr "رنگ اولیه"
+
+msgid "Primary provider:"
+msgstr "ارائه دهنده اصلی:"
+
+msgid "Process not more than"
+msgstr "فرآیند نه بیشتر از"
+
+msgid "Process not more than:"
+msgstr "فرآیند نه بیشتر از:"
+
+msgid "Process only tiles  with version:"
+msgstr "فقط کاشی ها را با نسخه پردازش کنید:"
+
+msgid "Processed"
+msgstr "پردازش شده است"
+
+msgid "Processed at: %.8f sec."
+msgstr "پردازش در: %8f ثانیه."
+
+msgid "Processed total:"
+msgstr "کل پردازش شده:"
+
+msgid "Processed:"
+msgstr "پردازش شده:"
+
+msgid "Processing tile: %0:s ..."
+msgstr "در حال پردازش کاشی: %0:s..."
+
+msgid "Product ID"
+msgstr "شناسه محصول"
+
+msgid "Product Name"
+msgstr "نام محصول"
+
+msgid "Product:"
+msgstr "محصول:"
+
+msgid "Project"
+msgstr "پروژه"
+
+msgid "Project New Placemark"
+msgstr "مکان نشانک پروژه جدید"
+
+msgid "Projected Coordinates"
+msgstr "مختصات پیش بینی شده"
+
+msgid "Projection"
+msgstr "فرافکنی"
+
+msgid "Projection isn't selected"
+msgstr "طرح ریزی انتخاب نشده است"
+
+msgid "Projection of layer"
+msgstr "طرح ریزی لایه"
+
+msgid "Projection of map"
+msgstr "طرح ریزی نقشه"
+
+msgid "Projection:"
+msgstr "فرافکنی:"
+
+msgid "Properties"
+msgstr "خواص"
+
+msgid "Provider:"
+msgstr "ارائه دهنده:"
+
+msgid "Proxy authorization error"
+msgstr "خطای مجوز پروکسی"
+
+msgid "Proxy login:"
+msgstr "ورود به سیستم پروکسی:"
+
+msgid "Proxy password:"
+msgstr "رمز عبور پروکسی:"
+
+msgid "Quality (for JPEG):"
+msgstr "کیفیت (برای JPEG):"
+
+msgid "Quality, %"
+msgstr "کیفیت، %"
+
+msgid "Queue"
+msgstr "صف"
+
+msgid "Quit"
+msgstr "ترک کنید"
+
+msgid "RAM"
+msgstr "RAM"
+
+msgid "RAW: Fill line failure!"
+msgstr "RAW: پر کردن خط شکست!"
+
+msgid "RMP raster map for Magellan"
+msgstr "نقشه شطرنجی RMP برای ماژلان"
+
+msgid "RMaps (SQLite3)"
+msgstr "RMaps (SQLite3)"
+
+msgid "Radius"
+msgstr "شعاع"
+
+msgid ""
+"Re-compress JPEG tiles\n"
+"Note: Non-JPEG tiles are always recompressed"
+msgstr ""
+"کاشی های JPEG را دوباره فشرده کنید\n"
+"توجه: کاشی های غیر JPEG همیشه دوباره فشرده می شوند"
+
+msgid "Read only mode"
+msgstr "حالت فقط خواندن"
+
+msgid "Read-Only"
+msgstr "فقط خواندنی"
+
+msgid "Recreate target database if exists"
+msgstr "در صورت وجود پایگاه داده هدف را دوباره ایجاد کنید"
+
+msgid "Rectangular Selection"
+msgstr "انتخاب مستطیلی"
+
+msgid "Redraw interval (ms):"
+msgstr "بازه ترسیم مجدد (ms):"
+
+msgid "Refresh"
+msgstr "تازه کردن"
+
+msgid "Refresh rate (ms)"
+msgstr "نرخ تازه‌سازی (میلی‌ثانیه)"
+
+msgid "Relative path to tiles"
+msgstr "مسیر نسبی به کاشی"
+
+msgid "Release (stable)"
+msgstr "انتشار (پایدار)"
+
+msgid "Remove All"
+msgstr "حذف همه"
+
+msgid "Remove selected (Delete)"
+msgstr "حذف انتخاب شده (حذف)"
+
+msgid "Remove tiles"
+msgstr "کاشی ها را بردارید"
+
+msgid "Replace existing tiles"
+msgstr "کاشی های موجود را تعویض کنید"
+
+msgid "Required pointset is not found!"
+msgstr "امتیاز مورد نیاز یافت نشد!"
+
+msgid "Requires:"
+msgstr "نیاز دارد:"
+
+msgid "Reset"
+msgstr "بازنشانی کنید"
+
+msgid "Reset to default"
+msgstr "به حالت پیش فرض بازنشانی کنید"
+
+msgid "Resize Algorithm:"
+msgstr "الگوریتم تغییر اندازه:"
+
+msgid "Resize algorithm:"
+msgstr "الگوریتم تغییر اندازه:"
+
+msgid "Restore"
+msgstr "بازیابی کنید"
+
+msgid "Restore download from last successful tile"
+msgstr "بازیابی دانلود از آخرین کاشی موفق"
+
+msgid "Resume"
+msgstr "رزومه"
+
+msgid "Resurs-DK"
+msgstr "Resurs-DK"
+
+msgid "Retry download if tile not found"
+msgstr "اگر کاشی یافت نشد دوباره دانلود کنید"
+
+msgid "Ring radius (m)"
+msgstr "شعاع حلقه (متر)"
+
+msgid "Roll backward to zoom in"
+msgstr "برای بزرگنمایی به عقب بچرخانید"
+
+msgid "Roscosmos (geoportal.ntsomz.ru)"
+msgstr "Roscosmos (geoportal.ntsomz.ru)"
+
+msgid "Round"
+msgstr "گرد"
+
+msgid "Route Calculation"
+msgstr "محاسبه مسیر"
+
+msgid "Run"
+msgstr "اجرا کنید"
+
+msgid "SAS.Planet"
+msgstr "SAS.Planet"
+
+msgid "SAS.Planet Development Team"
+msgstr "تیم توسعه SAS.Planet"
+
+msgid "SAS.Planet must be restarted for the changes to take effect"
+msgstr "SAS.Planet باید دوباره راه اندازی شود تا تغییرات اعمال شوند"
+
+msgid "SML"
+msgstr "SML"
+
+msgid "SPOT 5 - 10m Color"
+msgstr "نقطه 5 - 10 متر رنگ"
+
+msgid "SPOT 5 - 2.5m BW"
+msgstr "نقطه 5 - 2.5 متر BW"
+
+msgid "SPOT 5 - 2.5m Color"
+msgstr "نقطه 5 - 2.5 متر رنگ"
+
+msgid "SPOT 5 - 5m BW"
+msgstr "نقطه 5 - 5 متر BW"
+
+msgid "SPOT 5 - 5m Color"
+msgstr "نقطه 5 - 5 متر رنگ"
+
+msgid "SQLite3"
+msgstr "SQLite3"
+
+msgid "Satellite"
+msgstr "ماهواره"
+
+msgid "Satellite Signal Strength"
+msgstr "قدرت سیگنال ماهواره ای"
+
+msgid "Satellite Signal Strength:"
+msgstr "قدرت سیگنال ماهواره ای:"
+
+msgid "Satellites"
+msgstr "ماهواره ها"
+
+msgid "Satellites in range"
+msgstr "ماهواره در برد"
+
+msgid "Satellites in use"
+msgstr "ماهواره های در حال استفاده"
+
+msgid "Satellites not in range"
+msgstr "ماهواره ها در برد نیستند"
+
+msgid "Save"
+msgstr "ذخیره کنید"
+
+msgid "Save (Enter)"
+msgstr "ذخیره (ورود)"
+
+msgid "Save GeoRef info to Exif"
+msgstr "اطلاعات GeoRef را در Exif ذخیره کنید"
+
+msgid "Save as separate placemarks..."
+msgstr "ذخیره به عنوان مکان‌مارک جداگانه..."
+
+msgid "Save as..."
+msgstr "ذخیره به عنوان..."
+
+msgid "Save as... (Enter)"
+msgstr "ذخیره به عنوان... (وارد کنید)"
+
+msgid "Save current session"
+msgstr "ذخیره جلسه فعلی"
+
+msgid "Save merged polygon as..."
+msgstr "ذخیره چند ضلعی ادغام شده به عنوان..."
+
+msgid "Save only complete tiles"
+msgstr "فقط کاشی های کامل را ذخیره کنید"
+
+msgid "Save recovery information"
+msgstr "ذخیره اطلاعات بازیابی"
+
+msgid "Save selection info to file"
+msgstr "اطلاعات انتخاب را در فایل ذخیره کنید"
+
+msgid "Save to:"
+msgstr "ذخیره در:"
+
+msgid "Save zmp"
+msgstr "zmp را ذخیره کنید"
+
+msgid "Scale Legend"
+msgstr "افسانه مقیاس"
+
+msgid "Scale:"
+msgstr "مقیاس:"
+
+msgid "Science"
+msgstr "علم"
+
+msgid "Screen center"
+msgstr "مرکز صفحه نمایش"
+
+msgid "Search"
+msgstr "جستجو کنید"
+
+msgid "Search Results"
+msgstr "نتایج جستجو"
+
+msgid "Select Hybrid as main layer"
+msgstr "Hybrid را به عنوان لایه اصلی انتخاب کنید"
+
+msgid "Select Map as main layer"
+msgstr "Map را به عنوان لایه اصلی انتخاب کنید"
+
+msgid "Select Satellite as main layer"
+msgstr "ماهواره را به عنوان لایه اصلی انتخاب کنید"
+
+msgid "Select by Placemark"
+msgstr "با علامت مکان انتخاب کنید"
+
+msgid "Select data source"
+msgstr "منبع داده را انتخاب کنید"
+
+msgid "Select overlay layers"
+msgstr "لایه های همپوشانی را انتخاب کنید"
+
+msgid "Selected basemap"
+msgstr "نقشه پایه انتخاب شده"
+
+msgid ""
+"Selected category \"%0:s\" contain %d sub categories. Are you realy want to "
+"delete all of them?"
+msgstr ""
+"دسته انتخابی \"%0:s\" حاوی %d زیر دسته است. آیا واقعاً می خواهید همه آنها "
+"را حذف کنید؟"
+
+msgid ""
+"Selected resolution is too big for %s format!\n"
+"Widht = %d (max = %d)\n"
+"Height = %d (max = %d)\n"
+"Try select smaller region to stitch in %s or select other output format "
+"(ECW is the best)."
+msgstr ""
+"وضوح انتخاب شده برای قالب %s خیلی بزرگ است!\n"
+"عرض = %d (حداکثر = %d)\n"
+"ارتفاع = %d (حداکثر = %d)\n"
+"سعی کنید منطقه کوچکتری را برای دوخت در %s انتخاب کنید یا فرمت خروجی دیگری "
+"را انتخاب کنید (ECW بهترین است)."
+
+msgid "Selection Manager"
+msgstr "مدیر انتخاب"
+
+msgid "Selection by Coordinates"
+msgstr "انتخاب توسط مختصات"
+
+msgid "Selection manager"
+msgstr "مدیر انتخاب"
+
+msgid "Selections|*.hlg"
+msgstr "انتخاب ها|*.hlg"
+
+msgid "Sensors"
+msgstr "حسگرها"
+
+msgid "Serial port"
+msgstr "پورت سریال"
+
+msgid "Server returned type \"%0:s\", this is not bitmap image"
+msgstr "سرور نوع \"%0:s\" را برگرداند، این تصویر بیت مپ نیست"
+
+msgid "Server returned unexpected type \"%0:s\""
+msgstr "سرور نوع غیرمنتظره \"%0:s\" را برگرداند"
+
+msgid "Set Connection string first!"
+msgstr "ابتدا رشته اتصال را تنظیم کنید!"
+
+msgid "Set File name first!"
+msgstr "ابتدا نام فایل را تنظیم کنید!"
+
+msgid "Set Version to"
+msgstr "تنظیم نسخه به"
+
+msgid "Set all marks in all categories visible"
+msgstr "تنظیم همه علامت ها در همه دسته ها قابل مشاهده است"
+
+msgid "Set as default"
+msgstr "به عنوان پیش فرض تنظیم کنید"
+
+msgid "Set as default for new marks?"
+msgstr "به عنوان پیش فرض برای علائم جدید تنظیم شود؟"
+
+msgid "Set same version for all processed tiles:"
+msgstr "یک نسخه را برای همه کاشی های پردازش شده تنظیم کنید:"
+
+msgid "Settings"
+msgstr "تنظیمات"
+
+msgid "Shadow color"
+msgstr "رنگ سایه"
+
+msgid "Shift - snap to active grids (if enabled)"
+msgstr "Shift - رفتن به شبکه‌های فعال (در صورت فعال بودن)"
+
+msgid "Shortcut|*.lnk"
+msgstr "میانبر|*.lnk"
+
+msgid "Show Download Info"
+msgstr "نمایش اطلاعات دانلود"
+
+msgid "Show Elevation Info"
+msgstr "نمایش اطلاعات ارتفاع"
+
+msgid "Show Elevation Info From Any Available Source"
+msgstr "نمایش اطلاعات ارتفاع از هر منبع موجود"
+
+msgid "Show Elevation Info In Status Bar"
+msgstr "نمایش اطلاعات ارتفاع در نوار وضعیت"
+
+msgid "Show GPS Track"
+msgstr "نمایش مسیر GPS"
+
+msgid "Show GPS track"
+msgstr "نمایش مسیر GPS"
+
+msgid "Show Logo on startup"
+msgstr "نمایش لوگو هنگام راه اندازی"
+
+msgid "Show LonLat Info"
+msgstr "نمایش اطلاعات LonLat"
+
+msgid "Show Meter Per Pixel Info"
+msgstr "نمایش اطلاعات متر در هر پیکسل"
+
+msgid "Show Primary Map Tile"
+msgstr "نمایش کاشی نقشه اولیه"
+
+msgid "Show Queue Info"
+msgstr "نمایش اطلاعات صف"
+
+msgid "Show Tile Path Info"
+msgstr "نمایش اطلاعات مسیر کاشی"
+
+msgid "Show Time Zone Info"
+msgstr "نمایش اطلاعات منطقه زمانی"
+
+msgid "Show Vertical Scale Legend"
+msgstr "نمایش افسانه مقیاس عمودی"
+
+msgid "Show Zoom Info"
+msgstr "نمایش اطلاعات زوم"
+
+msgid "Show all placemarks"
+msgstr "نمایش همه مکان‌ها"
+
+msgid "Show azimuth"
+msgstr "نشان دادن آزیموت"
+
+msgid "Show for..."
+msgstr "نمایش برای ..."
+
+msgid "Show map name on toolbar"
+msgstr "نمایش نام نقشه در نوار ابزار"
+
+msgid "Show on map"
+msgstr "نمایش روی نقشه"
+
+msgid "Show only new"
+msgstr "نمایش فقط جدید"
+
+msgid "Show only selected placemarks"
+msgstr "فقط مکان‌نماهای انتخاب شده را نشان دهید"
+
+msgid "Show tooltips"
+msgstr "نمایش نکات ابزار"
+
+msgid "Show/Hide Captions"
+msgstr "نمایش/پنهان کردن زیرنویس ها"
+
+msgid "Show/Hide Password"
+msgstr "نمایش/پنهان کردن رمز عبور"
+
+msgid "Shows GPS Unit info"
+msgstr "اطلاعات واحد GPS را نشان می دهد"
+
+msgid "Shows GPS altitude"
+msgstr "ارتفاع GPS را نشان می دهد"
+
+msgid "Shows Satellite Signal Strength bars"
+msgstr "نوارهای قدرت سیگنال ماهواره را نشان می دهد"
+
+msgid "Shows Sunraise time for current position"
+msgstr "زمان طلوع آفتاب را برای موقعیت فعلی نشان می دهد"
+
+msgid "Shows Sunset time for current position"
+msgstr "زمان غروب آفتاب را برای موقعیت فعلی نشان می دهد"
+
+msgid "Shows UTC time"
+msgstr "زمان UTC را نشان می دهد"
+
+msgid "Shows average speed"
+msgstr "سرعت متوسط ​​را نشان می دهد"
+
+msgid "Shows battery status"
+msgstr "وضعیت باتری را نشان می دهد"
+
+msgid "Shows current speed"
+msgstr "سرعت فعلی را نشان می دهد"
+
+msgid "Shows differential GPS"
+msgstr "GPS دیفرانسیل را نشان می دهد"
+
+msgid "Shows distance since last GPS connection"
+msgstr "فاصله از آخرین اتصال GPS را نشان می دهد"
+
+msgid "Shows distance to selected placemark"
+msgstr "فاصله تا علامت مکان انتخابی را نشان می دهد"
+
+msgid "Shows horizontal dilution of precision"
+msgstr "رقت افقی دقت را نشان می دهد"
+
+msgid "Shows local time"
+msgstr "زمان محلی را نشان می دهد"
+
+msgid "Shows maximum speed"
+msgstr "حداکثر سرعت را نشان می دهد"
+
+msgid "Shows the course"
+msgstr "دوره را نشان می دهد"
+
+msgid "Shows total distance"
+msgstr "فاصله کل را نشان می دهد"
+
+msgid "Shows vertical dilution of precision"
+msgstr "رقت عمودی دقت را نشان می دهد"
+
+msgid "Size of answer is zero"
+msgstr "اندازه پاسخ صفر است"
+
+msgid "Size:"
+msgstr "اندازه:"
+
+msgid "Size: %0:dx%1:d. Split to %2:d files"
+msgstr "اندازه: %0:dx%1:d. تقسیم به %2:d فایل"
+
+msgid "Skipped:"
+msgstr "رد شد:"
+
+msgid "Sleep on reset connection, ms"
+msgstr "Sleep on reset connection، ms"
+
+msgid "Snap to Existing Markers"
+msgstr "به نشانگرهای موجود ضربه بزنید"
+
+msgid "Source Cache"
+msgstr "کش منبع"
+
+msgid "Source point type"
+msgstr "نوع نقطه منبع"
+
+msgid "Sources"
+msgstr "منابع"
+
+msgid "Sources:"
+msgstr "منابع:"
+
+msgid "Speed"
+msgstr "سرعت"
+
+msgid "Split Line"
+msgstr "اسپلیت لاین"
+
+msgid "Split image"
+msgstr "تقسیم تصویر"
+
+msgid "Split selection to, parts*:"
+msgstr "تقسیم انتخاب به قطعات*:"
+
+msgid "Start"
+msgstr "شروع کنید"
+
+msgid "Start paused"
+msgstr "شروع مکث شد"
+
+msgid "Status Bar"
+msgstr "نوار وضعیت"
+
+msgid "Stitch"
+msgstr "بخیه بزنید"
+
+msgid "Stitch selection"
+msgstr "انتخاب بخیه"
+
+msgid "Stitch: %0:dx%1:d (%2:d) files"
+msgstr "بخیه: %0:dx%1:d (%2:d) فایل"
+
+msgid "Stitching the map"
+msgstr "دوختن نقشه"
+
+msgid "Store blank tiles"
+msgstr "کاشی های خالی را ذخیره کنید"
+
+msgid "Store info about not found tiles"
+msgstr "اطلاعات فروشگاه در مورد کاشی های یافت نشد"
+
+msgid "Store selection as Poligon"
+msgstr "انتخاب فروشگاه به عنوان پولیگون"
+
+msgid "Successfully compiled"
+msgstr "با موفقیت گردآوری شد"
+
+msgid "Successfully executed"
+msgstr "با موفقیت اجرا شد"
+
+msgid "Sunraise time"
+msgstr "زمان طلوع آفتاب"
+
+msgid "Sunraise time:"
+msgstr "زمان طلوع آفتاب:"
+
+msgid "Sunset time"
+msgstr "زمان غروب آفتاب"
+
+msgid "Sunset time:"
+msgstr "زمان غروب آفتاب:"
+
+msgid "Syntax Check"
+msgstr "بررسی نحو"
+
+msgid "TBXToolbar3"
+msgstr "TBXToolbar3"
+
+msgid ""
+"Table not found and cannot be created (possibly due to insufficient "
+"privileges or readonly external tile storage)"
+msgstr ""
+"جدول پیدا نشد و ایجاد نمی‌شود (احتمالاً به دلیل امتیازات ناکافی یا فضای "
+"ذخیره‌سازی کاشی خارجی فقط خواندنی)"
+
+msgid "Task"
+msgstr "وظیفه"
+
+msgid "Text color"
+msgstr "رنگ متن"
+
+msgid "Text color:"
+msgstr "رنگ متن:"
+
+msgid "The Name can't be empty!"
+msgstr "نام نمی تواند خالی باشد!"
+
+msgid "The feature can be used on polygons and polylines"
+msgstr "این ویژگی را می توان در چند ضلعی و چند خطی استفاده کرد"
+
+msgid ""
+"The number of JPEG files will exceed 100. If your\n"
+"navigation device split the image using\n"
+"\"Manage Selection - Stitch\" window\n"
+"and use resulting KMZ files separately"
+msgstr ""
+"تعداد فایل های JPEG از 100 بیشتر خواهد شد\n"
+"دستگاه ناوبری تصویر را با استفاده از تقسیم می کند\n"
+"پنجره \"Manage Selection - Stitch\".\n"
+"و از فایل های KMZ به طور جداگانه استفاده کنید"
+
+msgid "The task is completed!"
+msgstr "کار تمام شد!"
+
+msgid "The tile already exists"
+msgstr "کاشی از قبل وجود دارد"
+
+msgid "The tile is newer than the entered age, skipping."
+msgstr "کاشی جدیدتر از سن وارد شده است، پرش."
+
+msgid "The tile size is equal to the existing one, skipping."
+msgstr "اندازه کاشی برابر با یک موجود است، پرش."
+
+msgid "The tne is newer than the entered age, skipping."
+msgstr "Tne جدیدتر از سن وارد شده، پرش است."
+
+msgid "There are no available objects in the pool!"
+msgstr "هیچ شیء موجود در استخر وجود ندارد!"
+
+msgid "There is an error %1:s in map %0:s"
+msgstr "خطای %1:s در نقشه %0:s وجود دارد"
+
+msgid ""
+"This format doesn't support file name with characters not from current "
+"locale!"
+msgstr "این قالب از نام فایل با نویسه‌هایی که از منطقه فعلی نیستند پشتیبانی نمی‌کند!"
+
+msgid "This format supports file name with ASCII characters only!"
+msgstr "این فرمت فقط از نام فایل با کاراکترهای ASCII پشتیبانی می کند!"
+
+msgid "This is not simple file storage. Tile's file name does not exist."
+msgstr "این ذخیره سازی فایل ساده نیست. نام فایل کاشی وجود ندارد."
+
+msgid ""
+"This program is freeware, opensource and released under the GNU General "
+"Public License (GPLv3)"
+msgstr ""
+"این برنامه رایگان، منبع باز و تحت مجوز عمومی عمومی گنو (GPLv3) منتشر شده "
+"است."
+
+msgid "Tile"
+msgstr "کاشی"
+
+msgid ""
+"Tile %0:s is available in cache.\n"
+"Replace?"
+msgstr ""
+"کاشی %0:s در حافظه پنهان موجود است.\n"
+"جایگزین شود؟"
+
+msgid "Tile Boundaries"
+msgstr "مرزهای کاشی"
+
+msgid "Tile Map Service (TMS)"
+msgstr "سرویس نقشه کاشی (TMS)"
+
+msgid "Tile Map Service (TMS) cache folder:"
+msgstr "پوشه کش سرویس نقشه کاشی (TMS):"
+
+msgid "Tile Size"
+msgstr "اندازه کاشی"
+
+msgid "Tile borders:"
+msgstr "حاشیه کاشی:"
+
+msgid "Tile coordinates"
+msgstr "مختصات کاشی"
+
+msgid "Tile is not found!"
+msgstr "کاشی پیدا نشد!"
+
+msgid "Tile is not found! Status code %d"
+msgstr "کاشی پیدا نشد! کد وضعیت %d"
+
+msgid "Tile is not found! Zero result size"
+msgstr "کاشی پیدا نشد! اندازه نتیجه صفر"
+
+msgid "Tile is recognized as empty"
+msgstr "کاشی خالی تشخیص داده می شود"
+
+msgid "Tile with same size exists"
+msgstr "کاشی با همان اندازه وجود دارد"
+
+msgid "Tiles"
+msgstr "کاشی"
+
+msgid "Time Interval"
+msgstr "فاصله زمانی"
+
+msgid "Time remaining:"
+msgstr "زمان باقی مانده:"
+
+msgid "Time to reach:"
+msgstr "زمان رسیدن به:"
+
+msgid "To Archive"
+msgstr "به آرشیو"
+
+msgid "To Folder"
+msgstr "به پوشه"
+
+msgid "To zooms:"
+msgstr "برای بزرگنمایی:"
+
+msgid "Toolbars"
+msgstr "نوار ابزار"
+
+msgid "Total"
+msgstr "مجموع"
+
+msgid "Total to save:"
+msgstr "مجموع برای صرفه جویی:"
+
+msgid "Track width:"
+msgstr "عرض مسیر:"
+
+msgid "Try download if tne exists"
+msgstr "در صورت وجود، دانلود کنید"
+
+msgid "URL to Bing Maps"
+msgstr "URL به نقشه های بینگ"
+
+msgid "URL to Google Maps"
+msgstr "URL به Google Maps"
+
+msgid "URL to Layer Tile"
+msgstr "URL به کاشی لایه"
+
+msgid "URL to Nokia Map Creator"
+msgstr "نشانی وب نوکیا Map Creator"
+
+msgid "URL to Primary Map Tile"
+msgstr "URL به کاشی نقشه اولیه"
+
+msgid "URL to Rosreestr"
+msgstr "آدرس اینترنتی Rosreestr"
+
+msgid "URL to Terraserver"
+msgstr "URL به Terraserver"
+
+msgid "URL to Yandex.Maps"
+msgstr "URL به Yandex.Maps"
+
+msgid "URL to kosmosnimki.ru"
+msgstr "آدرس اینترنتی kosmosnimki.ru"
+
+msgid "URL to osm.org"
+msgstr "آدرس اینترنتی osm.org"
+
+msgid "UTC time"
+msgstr "زمان UTC"
+
+msgid "UTC time:"
+msgstr "زمان UTC:"
+
+msgid "Unable to fix position"
+msgstr "قادر به رفع موقعیت نیست"
+
+msgid "Unable to load map(s)! Aborting..."
+msgstr "بارگیری نقشه(ها) ممکن نیست! در حال سقط..."
+
+msgid "Unexpected content type %s"
+msgstr "نوع محتوای غیرمنتظره %s"
+
+msgid "Unexpected proxy authorization"
+msgstr "مجوز پروکسی غیرمنتظره"
+
+msgid "Ungroup"
+msgstr "لغو گروه کردن"
+
+msgid "Union (OR)"
+msgstr "اتحادیه (OR)"
+
+msgid "Unit info"
+msgstr "اطلاعات واحد"
+
+msgid "Unit info:"
+msgstr "اطلاعات واحد:"
+
+msgid "Unknown"
+msgstr "ناشناس"
+
+msgid "Unknown critical error at external tile storage"
+msgstr "خطای بحرانی ناشناخته در ذخیره سازی کاشی خارجی"
+
+msgid ""
+"Unknown error at external tile storage, see Storage Options for more "
+"information"
+msgstr ""
+"خطای ناشناخته در ذخیره سازی کاشی خارجی، برای اطلاعات بیشتر به گزینه های "
+"ذخیره سازی مراجعه کنید"
+
+msgid "Unknown error during download"
+msgstr "خطای ناشناخته در حین دانلود"
+
+msgid "Unknown status code %d"
+msgstr "کد وضعیت ناشناخته %d"
+
+msgid "Up"
+msgstr "بالا"
+
+msgid "Upper left corner"
+msgstr "گوشه سمت چپ بالا"
+
+msgid "Use Age Gradient"
+msgstr "از گرادیان سنی استفاده کنید"
+
+msgid "Use Deleted: Object is not exists!"
+msgstr "استفاده از حذف شده: شی وجود ندارد!"
+
+msgid "Use Layers from Lower Zooms"
+msgstr "از لایه‌های زوم پایین‌تر استفاده کنید"
+
+msgid "Use Maps from Lower Zooms"
+msgstr "از نقشه های Lower Zooms استفاده کنید"
+
+msgid "Use postprocessing settings"
+msgstr "از تنظیمات پس پردازش استفاده کنید"
+
+msgid "Use proxy (IP:port)"
+msgstr "استفاده از پروکسی (IP:port)"
+
+msgid "Use storage to check new images"
+msgstr "از فضای ذخیره سازی برای بررسی تصاویر جدید استفاده کنید"
+
+msgid "Use system proxy settings"
+msgstr "از تنظیمات پروکسی سیستم استفاده کنید"
+
+msgid "Use thumbnail as Icon"
+msgstr "از تصویر کوچک به عنوان نماد استفاده کنید"
+
+msgid "Use tile from lower zoom if tile not available"
+msgstr "اگر کاشی در دسترس نیست، از کاشی از زوم کمتر استفاده کنید"
+
+msgid "Use tiles from lower zooms (on unavalible tile)"
+msgstr "استفاده از کاشی هایی با زوم های کمتر (روی کاشی های غیرقابل دسترس)"
+
+msgid "Use xyz scheme"
+msgstr "از طرح xyz استفاده کنید"
+
+msgid "User Name:"
+msgstr "نام کاربری:"
+
+msgid "User defined"
+msgstr "کاربر تعریف شده است"
+
+msgid "Username"
+msgstr "نام کاربری"
+
+msgid "Value"
+msgstr "ارزش"
+
+msgid "Version"
+msgstr "نسخه"
+
+msgid "Version:"
+msgstr "نسخه:"
+
+msgid "Versions"
+msgstr "نسخه ها"
+
+msgid "View"
+msgstr "مشاهده کنید"
+
+msgid "Visible Area"
+msgstr "منطقه قابل مشاهده"
+
+msgid "Visible on zooms:"
+msgstr "قابل مشاهده در زوم:"
+
+msgid "WS deg. (W12.1233°)"
+msgstr "درجه WS (W12.1233°)"
+
+msgid "WS deg.min. (W12°23.454)"
+msgstr "WS deg.min. (W12°23.454)"
+
+msgid "WS deg.min.sec. (W12°23\"43.35')"
+msgstr "WS deg.min.sec. (W12°23\"43.35')"
+
+msgid "Web Site (http://www.sasgis.org)"
+msgstr "وب سایت (http://www.sasgis.org)"
+
+msgid "Width"
+msgstr "عرض"
+
+msgid "Width:"
+msgstr "عرض:"
+
+msgid "Within Time Interval"
+msgstr "در بازه زمانی"
+
+msgid "Word Wrap"
+msgstr "بسته بندی کلمات"
+
+msgid "Yes"
+msgstr "بله"
+
+msgid "You must MERGE polygons first!"
+msgstr "ابتدا باید چند ضلعی ها را ادغام کنید!"
+
+msgid "You must add at least TWO polygons!"
+msgstr "شما باید حداقل دو چند ضلعی اضافه کنید!"
+
+msgid "You need at least one MAP among your ZMP files"
+msgstr "شما به حداقل یک MAP در بین فایل های ZMP خود نیاز دارید"
+
+msgid "Your version:"
+msgstr "نسخه شما:"
+
+msgid "Z-Order:"
+msgstr "Z-Order:"
+
+msgid "ZMP Filename"
+msgstr "نام فایل ZMP"
+
+msgid ""
+"ZMP has been modified, but not saved yet!\n"
+"\n"
+"Do you really want to close without saving?"
+msgstr ""
+"ZMP اصلاح شده است، اما هنوز ذخیره نشده است!\n"
+"\n"
+"آیا واقعاً می خواهید بدون ذخیره ببندید؟"
+
+msgid "ZMP | *.zmp"
+msgstr "ZMP | *.zmp"
+
+msgid "ZMP:"
+msgstr "ZMP:"
+
+msgid "Zone:"
+msgstr "منطقه:"
+
+msgid "Zoom"
+msgstr "بزرگنمایی ضربه بزنید؛"
+
+msgid "Zoom Animation"
+msgstr "زوم انیمیشن"
+
+msgid "Zoom In"
+msgstr "بزرگنمایی"
+
+msgid "Zoom Out"
+msgstr "بزرگنمایی"
+
+msgid "Zoom to Cursor"
+msgstr "زوم به مکان نما"
+
+msgid "Zoom:"
+msgstr "بزرگنمایی:"
+
+msgid "Zooms:"
+msgstr "بزرگنمایی ها:"
+
+msgid "[clip]"
+msgstr "[کلیپ]"
+
+msgid "[subject]"
+msgstr "[موضوع]"
+
+msgid "calc..."
+msgstr "کالک..."
+
+msgid "cm"
+msgstr "سانتی متر"
+
+msgid "files"
+msgstr "فایل ها"
+
+msgid "from"
+msgstr "از"
+
+msgid "ha"
+msgstr "در هکتار"
+
+msgid "horizontally:"
+msgstr "به صورت افقی:"
+
+msgid "iPhone (version 2.2 and above, 128x128)"
+msgstr "آیفون (نسخه 2.2 و بالاتر، 128x128)"
+
+msgid "iPhone (version prior to 2.2, 64x64)"
+msgstr "آیفون (نسخه قبل از 2.2، 64x64)"
+
+msgid "km"
+msgstr "کیلومتر"
+
+msgid "km/h"
+msgstr "کیلومتر در ساعت"
+
+msgid "km2"
+msgstr "کیلومتر مربع"
+
+msgid "m"
+msgstr "متر"
+
+msgid "m2"
+msgstr "متر مربع"
+
+msgid "mbtiles|*.mbtiles"
+msgstr "mbtiles|*.mbtiles"
+
+msgid "only created before"
+msgstr "فقط قبلا ایجاد شده است"
+
+msgid "only if different"
+msgstr "فقط اگر متفاوت باشد"
+
+msgid "rmp|*.rmp"
+msgstr "rmp|*.rmp"
+
+msgid "searching"
+msgstr "جستجو"
+
+msgid "size:"
+msgstr "اندازه:"
+
+msgid "tbTop"
+msgstr "tbTop"
+
+msgid "to"
+msgstr "به"
+
+msgid "vertically:"
+msgstr "به صورت عمودی:"
+
+msgid "yournavigation.org (OSM)"
+msgstr "yournavigation.org (OSM)"


### PR DESCRIPTION
Hello,

We have added a Persian (Farsi) translation for SAS Planet. The reason behind this contribution is that many Persian-speaking users face difficulties using the application due to the lack of localization.

The translation was initially generated using Google Translate, and we have carefully reviewed and improved it to ensure it is accurate and acceptable for Persian users.

We believe this contribution will make SAS Planet more accessible to a wider audience and benefit many users who speak Persian.

Thank you for considering this contribution!